### PR TITLE
Background Y position (F618) is not unused, it's used for copying to VRAM

### DIFF
--- a/Variables.asm
+++ b/Variables.asm
@@ -110,7 +110,7 @@ v_vdp_buffer1:	equ $FFFFF60C	; VDP instruction buffer (2 bytes)
 
 v_demolength:	equ $FFFFF614	; the length of a demo in frames (2 bytes)
 v_scrposy_dup:	equ $FFFFF616	; screen position y (duplicate) (2 bytes)
-v_bgscreenposy_dup_unused:	equ $FFFFF618	; background screen position y (duplicate) (2 bytes)
+v_bgscrposy_dup:	equ $FFFFF618	; background screen position y (duplicate) (2 bytes)
 v_scrposx_dup:	equ $FFFFF61A	; screen position x (duplicate) (2 bytes)
 v_bgscreenposx_dup_unused:	equ $FFFFF61C	; background screen position x (duplicate) (2 bytes)
 v_bg3screenposy_dup_unused:	equ $FFFFF61E	; (2 bytes)

--- a/_inc/DeformLayers (JP1).asm
+++ b/_inc/DeformLayers (JP1).asm
@@ -20,7 +20,7 @@ loc_628E:
 		bsr.w	ScrollVertical
 		bsr.w	DynamicLevelEvents
 		move.w	(v_screenposy).w,(v_scrposy_dup).w
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		moveq	#0,d0
 		move.b	(v_zone).w,d0
 		add.w	d0,d0
@@ -68,7 +68,7 @@ Deform_GHZ:
 		moveq	#0,d0
 loc_62F6:
 		move.w	d0,d4
-		move.w	d0,(v_bgscreenposy_dup_unused).w
+		move.w	d0,(v_bgscrposy_dup).w
 		move.w	(v_screenposx).w,d0
 		cmpi.b	#id_Title,($FFFFF600).w
 		bne.s	loc_630A
@@ -154,7 +154,7 @@ Deform_LZ:
 		ext.l	d5
 		asl.l	#7,d5
 		bsr.w	ScrollBlock1
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		lea	(Lz_Scroll_Data),a3
 		lea	(Drown_WobbleData),a2
 		move.b	($FFFFF7D8).w,d2
@@ -255,7 +255,7 @@ loc_6590:
 		move.w	d0,(v_bg2screenposy).w
 		move.w	d0,(v_bg3screenposy).w
 		bsr.w	ScrollBlock2
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		move.b	(v_bg1_scroll_flags).w,d0
 		or.b	(v_bg2_scroll_flags).w,d0
 		or.b	d0,(v_bg3_scroll_flags).w
@@ -327,7 +327,7 @@ Deform_SLZ:
 		ext.l	d5
 		asl.l	#7,d5
 		bsr.w	Bg_Scroll_Y
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		lea	($FFFFA800).w,a1
 		move.w	(v_screenposx).w,d2
 		neg.w	d2
@@ -426,7 +426,7 @@ Deform_SYZ:
 		asl.l	#1,d5
 		add.l	d1,d5
 		bsr.w	Bg_Scroll_Y
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		lea	($FFFFA800).w,a1
 		move.w	(v_screenposx).w,d2
 		neg.w	d2
@@ -526,7 +526,7 @@ Deform_SBZ:
 		move.w	(v_bgscreenposy).w,d0
 		move.w	d0,(v_bg2screenposy).w
 		move.w	d0,(v_bg3screenposy).w
-		move.w	d0,(v_bgscreenposy_dup_unused).w
+		move.w	d0,(v_bgscrposy_dup).w
 		move.b	(v_bg1_scroll_flags).w,d0
 		or.b	(v_bg3_scroll_flags).w,d0
 		or.b	d0,(v_bg2_scroll_flags).w
@@ -588,7 +588,7 @@ Bg_Scroll_SBz_2:;loc_68A2:
 		ext.l	d5
 		asl.l	#5,d5
 		bsr.w	ScrollBlock1
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		lea	(v_hscrolltablebuffer).w,a1
 		move.w	#223,d1
 		move.w	(v_screenposx).w,d0

--- a/_inc/DeformLayers.asm
+++ b/_inc/DeformLayers.asm
@@ -22,7 +22,7 @@ loc_628E:
 		move.w	(v_screenposx).w,(v_scrposx_dup).w
 		move.w	(v_screenposy).w,(v_scrposy_dup).w
 		move.w	(v_bgscreenposx).w,(v_bgscreenposx_dup_unused).w
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		move.w	(v_bg3screenposx).w,(v_bg3screenposx_dup_unused).w
 		move.w	(v_bg3screenposy).w,(v_bg3screenposy_dup_unused).w
 		moveq	#0,d0
@@ -67,7 +67,7 @@ Deform_GHZ:
 		move.w	d0,(v_bg2screenposy).w
 		move.w	d0,d4
 		bsr.w	ScrollBlock3
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		move.w	#$6F,d1
 		sub.w	d4,d1
 		move.w	(v_screenposx).w,d0
@@ -132,7 +132,7 @@ Deform_LZ:
 		ext.l	d5
 		asl.l	#7,d5
 		bsr.w	ScrollBlock1
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		lea	(v_hscrolltablebuffer).w,a1
 		move.w	#223,d1
 		move.w	(v_screenposx).w,d0
@@ -178,7 +178,7 @@ Deform_MZ:
 loc_6402:
 		move.w	d0,(v_bg2screenposy).w
 		bsr.w	ScrollBlock3
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		lea	(v_hscrolltablebuffer).w,a1
 		move.w	#223,d1
 		move.w	(v_screenposx).w,d0
@@ -208,7 +208,7 @@ Deform_SLZ:
 		ext.l	d5
 		asl.l	#7,d5
 		bsr.w	ScrollBlock2
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		bsr.w	Deform_SLZ_2
 		lea	($FFFFA800).w,a2
 		move.w	(v_bgscreenposy).w,d0
@@ -321,7 +321,7 @@ Deform_SYZ:
 		asl.l	#1,d5
 		add.l	d1,d5
 		bsr.w	ScrollBlock1
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		lea	(v_hscrolltablebuffer).w,a1
 		move.w	#223,d1
 		move.w	(v_screenposx).w,d0
@@ -352,7 +352,7 @@ Deform_SBZ:
 		asl.l	#4,d5
 		asl.l	#1,d5
 		bsr.w	ScrollBlock1
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 		lea	(v_hscrolltablebuffer).w,a1
 		move.w	#223,d1
 		move.w	(v_screenposx).w,d0

--- a/sonic.asm
+++ b/sonic.asm
@@ -3532,7 +3532,7 @@ SS_BGAnimate:
 		move.w	($FFFFF7A0).w,d0
 		bne.s	loc_4BF6
 		move.w	#0,(v_bgscreenposy).w
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 
 loc_4BF6:
 		cmpi.w	#8,d0
@@ -3541,7 +3541,7 @@ loc_4BF6:
 		bne.s	loc_4C10
 		addq.w	#1,(v_bg3screenposx).w
 		addq.w	#1,(v_bgscreenposy).w
-		move.w	(v_bgscreenposy).w,(v_bgscreenposy_dup_unused).w
+		move.w	(v_bgscreenposy).w,(v_bgscrposy_dup).w
 
 loc_4C10:
 		moveq	#0,d0


### PR DESCRIPTION
As seen here.

		move.l	#$40000010,(vdp_control_port).l
		move.l	(v_scrposy_dup).w,(vdp_data_port).l ; send screen y-axis pos. to VSRAM

v_bgscreenposy_dup_unused was renamed to v_bgscrposy_dup