### PR TITLE
Made saws and pizza cutters (Obj6A) actually show up in SonLVL

### DIFF
--- a/SonLVL INI Files/MZ/PushableBlocks.xml
+++ b/SonLVL INI Files/MZ/PushableBlocks.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ObjDef xmlns="http://www.sonicretro.org" Name="Movable Block" Image="frame0">
+  <Images>
+    <ImageFromMappings id="frame0">
+      <ArtFile filename="../artnem/MZ Green Pushable Block.bin"/>
+      <MapFile type="ASM" filename="../_maps/Pushable Blocks.asm" frame="0" startpal="2"/>
+    </ImageFromMappings>
+    <ImageFromMappings id="frame1">
+      <ArtFile filename="../artnem/MZ Green Pushable Block.bin"/>
+      <MapFile type="ASM" filename="../_maps/Pushable Blocks.asm" frame="1" startpal="2"/>
+    </ImageFromMappings>
+  </Images>
+ <Subtypes>
+    <Subtype id="00" name="1 block" image="frame0"/>
+    <Subtype id="81" name="4 blocks" image="frame1"/>
+  </Subtypes>
+</ObjDef>

--- a/SonLVL INI Files/SBZ/SawsandPizzaCutters.xml
+++ b/SonLVL INI Files/SBZ/SawsandPizzaCutters.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ObjDef xmlns="http://www.sonicretro.org" Name="Saws and Pizza Cutters" Image="frame0">
+  <Images>
+    <ImageFromMappings id="frame0">
+      <ArtFile filename="../artnem/SBZ Pizza Cutter.bin"/>
+      <MapFile type="ASM" filename="../_maps/Saws and Pizza Cutters.asm" frame="0" startpal="2"/>
+    </ImageFromMappings>
+    <ImageFromMappings id="frame1">
+      <ArtFile filename="../artnem/SBZ Pizza Cutter.bin"/>
+      <MapFile type="ASM" filename="../_maps/Saws and Pizza Cutters.asm" frame="2" startpal="2"/>
+    </ImageFromMappings>
+  </Images>
+ <Subtypes>
+    <Subtype id="00" name="Pizza cutter - Stationary" image="frame0"/>
+    <Subtype id="01" name="Pizza cutter - Moves left and right" image="frame0"/>
+    <Subtype id="02" name="Pizza cutter - Moves up and down" image="frame0"/>
+    <Subtype id="03" name="Saw - Moves right" image="frame1"/>
+    <Subtype id="04" name="Saw - Moves left" image="frame1"/>
+  </Subtypes>
+</ObjDef>

--- a/SonLVL INI Files/objMZ.ini
+++ b/SonLVL INI Files/objMZ.ini
@@ -21,12 +21,7 @@ pal=2
 [32]
 xmlfile=MZ/Switch.xml
 [33]
-name=Movable Block
-art=../artnem/MZ Green Pushable Block.bin
-mapasm=../_maps/Pushable Blocks.asm
-frame=0
-pal=2
-rememberstate=True
+xmlfile=MZ/PushableBlocks.xml
 [45]
 codefile=MZ/SidewaysStomper.cs
 codetype=S1ObjectDefinitions.MZ.SidewaysStomper

--- a/SonLVL INI Files/objSBZ.ini
+++ b/SonLVL INI Files/objSBZ.ini
@@ -38,7 +38,7 @@ name=Conveyor Belt
 [69]
 xmlfile=SBZ/SpinningPlatform.xml
 [6A]
-name=Saws and Pizza Cutters
+xmlfile=SBZ/SawsandPizzaCutters.xml
 [6B]
 name=Stomper and Door
 [6C]


### PR DESCRIPTION
Obj6A (saws and pizza cutters) now actually show up in SonLVL rather than just being a question mark. Also has all subtypes listed. I also fixed subtype $81 of pushable blocks (Obj33) to now show 4 blocks instead of 1 block in SonLVL.