### PR TITLE
Add constants for boss locations

### DIFF
--- a/Constants.asm
+++ b/Constants.asm
@@ -368,3 +368,33 @@ fr_Float6:	equ $54
 fr_Injury:	equ $55
 fr_GetAir:	equ $56
 fr_WaterSlide:	equ $57
+
+; Boss locations
+; The main values are based on where the camera boundaries mainly lie
+; The end values are where the camera scrolls towards after defeat
+boss_ghz_x:	equ $2960		; Green Hill Zone
+boss_ghz_y:	equ $300
+boss_ghz_end:	equ boss_ghz_x+$160
+
+boss_lz_x:	equ $1DE0		; Labyrinth Zone
+boss_lz_y:	equ $C0
+boss_lz_end:	equ boss_lz_x+$250
+
+boss_mz_x:	equ $1800		; Marble Zone
+boss_mz_y:	equ $210
+boss_mz_end:	equ boss_mz_x+$160
+
+boss_slz_x:	equ $2000		; Star Light Zone
+boss_slz_y:	equ $210
+boss_slz_end:	equ boss_slz_x+$160
+
+boss_syz_x:	equ $2C00		; Spring Yard Zone
+boss_syz_y:	equ $4CC
+boss_syz_end:	equ boss_syz_x+$140
+
+boss_sbz2_x:	equ $2050		; Scrap Brain Zone Act 2 Cutscene
+boss_sbz2_y:	equ $510
+
+boss_fz_x:	equ $2450		; Final Zone
+boss_fz_y:	equ $510
+boss_fz_end:	equ boss_fz_x+$2B0

--- a/_inc/DynamicLevelEvents.asm
+++ b/_inc/DynamicLevelEvents.asm
@@ -135,7 +135,7 @@ locret_6E96:
 ; ===========================================================================
 
 loc_6E98:
-		move.w	#$300,(v_limitbtm1).w
+		move.w	#boss_ghz_y,(v_limitbtm1).w
 		addq.b	#2,(v_dle_routine).w
 		rts	
 ; ===========================================================================
@@ -146,13 +146,13 @@ DLE_GHZ3boss:
 		subq.b	#2,(v_dle_routine).w
 
 loc_6EB0:
-		cmpi.w	#$2960,(v_screenposx).w
+		cmpi.w	#boss_ghz_x,(v_screenposx).w
 		bcs.s	locret_6EE8
 		bsr.w	FindFreeObj
 		bne.s	loc_6ED0
 		_move.b	#id_BossGreenHill,0(a1) ; load GHZ boss	object
-		move.w	#$2A60,obX(a1)
-		move.w	#$280,obY(a1)
+		move.w	#boss_ghz_x+$100,obX(a1)
+		move.w	#boss_ghz_y-$80,obY(a1)
 
 loc_6ED0:
 		move.w	#bgm_Boss,d0
@@ -205,9 +205,9 @@ DLE_LZ3:
 loc_6F28:
 		tst.b	(v_dle_routine).w
 		bne.s	locret_6F64
-		cmpi.w	#$1CA0,(v_screenposx).w
+		cmpi.w	#boss_lz_x-$140,(v_screenposx).w
 		bcs.s	locret_6F62
-		cmpi.w	#$600,(v_screenposy).w
+		cmpi.w	#boss_lz_y+$540,(v_screenposy).w
 		bcc.s	locret_6F62
 		bsr.w	FindFreeObj
 		bne.s	loc_6F4A
@@ -383,16 +383,16 @@ off_7098:	dc.w DLE_MZ3boss-off_7098
 
 DLE_MZ3boss:
 		move.w	#$720,(v_limitbtm1).w
-		cmpi.w	#$1560,(v_screenposx).w
+		cmpi.w	#boss_mz_x-$2A0,(v_screenposx).w
 		bcs.s	locret_70E8
-		move.w	#$210,(v_limitbtm1).w
-		cmpi.w	#$17F0,(v_screenposx).w
+		move.w	#boss_mz_y,(v_limitbtm1).w
+		cmpi.w	#boss_mz_x-$10,(v_screenposx).w
 		bcs.s	locret_70E8
 		bsr.w	FindFreeObj
 		bne.s	loc_70D0
 		_move.b	#id_BossMarble,0(a1) ; load MZ boss object
-		move.w	#$19F0,obX(a1)
-		move.w	#$22C,obY(a1)
+		move.w	#boss_mz_x+$1F0,obX(a1)
+		move.w	#boss_mz_y+$1C,obY(a1)
 
 loc_70D0:
 		move.w	#bgm_Boss,d0
@@ -443,9 +443,9 @@ off_7118:	dc.w DLE_SLZ3main-off_7118
 ; ===========================================================================
 
 DLE_SLZ3main:
-		cmpi.w	#$1E70,(v_screenposx).w
+		cmpi.w	#boss_slz_x-$190,(v_screenposx).w
 		bcs.s	locret_7130
-		move.w	#$210,(v_limitbtm1).w
+		move.w	#boss_slz_y,(v_limitbtm1).w
 		addq.b	#2,(v_dle_routine).w
 
 locret_7130:
@@ -453,7 +453,7 @@ locret_7130:
 ; ===========================================================================
 
 DLE_SLZ3boss:
-		cmpi.w	#$2000,(v_screenposx).w
+		cmpi.w	#boss_slz_x,(v_screenposx).w
 		bcs.s	locret_715C
 		bsr.w	FindFreeObj
 		bne.s	loc_7144
@@ -522,7 +522,7 @@ off_71B2:	dc.w DLE_SYZ3main-off_71B2
 ; ===========================================================================
 
 DLE_SYZ3main:
-		cmpi.w	#$2AC0,(v_screenposx).w
+		cmpi.w	#boss_syz_x-$140,(v_screenposx).w
 		bcs.s	locret_71CE
 		bsr.w	FindFreeObj
 		bne.s	locret_71CE
@@ -534,9 +534,9 @@ locret_71CE:
 ; ===========================================================================
 
 DLE_SYZ3boss:
-		cmpi.w	#$2C00,(v_screenposx).w
+		cmpi.w	#boss_syz_x,(v_screenposx).w
 		bcs.s	locret_7200
-		move.w	#$4CC,(v_limitbtm1).w
+		move.w	#boss_syz_y,(v_limitbtm1).w
 		bsr.w	FindFreeObj
 		bne.s	loc_71EC
 		move.b	#id_BossSpringYard,(a1) ; load SYZ boss	object
@@ -603,7 +603,7 @@ DLE_SBZ2main:
 		move.w	#$800,(v_limitbtm1).w
 		cmpi.w	#$1800,(v_screenposx).w
 		bcs.s	locret_727A
-		move.w	#$510,(v_limitbtm1).w
+		move.w	#boss_sbz2_y,(v_limitbtm1).w
 		cmpi.w	#$1E00,(v_screenposx).w
 		bcs.s	locret_727A
 		addq.b	#2,(v_dle_routine).w
@@ -613,7 +613,7 @@ locret_727A:
 ; ===========================================================================
 
 DLE_SBZ2boss:
-		cmpi.w	#$1EB0,(v_screenposx).w
+		cmpi.w	#boss_sbz2_x-$1A0,(v_screenposx).w
 		bcs.s	locret_7298
 		bsr.w	FindFreeObj
 		bne.s	locret_7298
@@ -628,7 +628,7 @@ locret_7298:
 ; ===========================================================================
 
 DLE_SBZ2boss2:
-		cmpi.w	#$1F60,(v_screenposx).w
+		cmpi.w	#boss_sbz2_x-$F0,(v_screenposx).w
 		bcs.s	loc_72B6
 		bsr.w	FindFreeObj
 		bne.s	loc_72B0
@@ -643,7 +643,7 @@ loc_72B6:
 ; ===========================================================================
 
 DLE_SBZ2end:
-		cmpi.w	#$2050,(v_screenposx).w
+		cmpi.w	#boss_sbz2_x,(v_screenposx).w
 		bcs.s	loc_72C2
 		rts	
 ; ===========================================================================
@@ -665,7 +665,7 @@ off_72D8:	dc.w DLE_FZmain-off_72D8, DLE_FZboss-off_72D8
 ; ===========================================================================
 
 DLE_FZmain:
-		cmpi.w	#$2148,(v_screenposx).w
+		cmpi.w	#boss_fz_x-$308,(v_screenposx).w
 		bcs.s	loc_72F4
 		addq.b	#2,(v_dle_routine).w
 		moveq	#plcid_FZBoss,d0
@@ -676,7 +676,7 @@ loc_72F4:
 ; ===========================================================================
 
 DLE_FZboss:
-		cmpi.w	#$2300,(v_screenposx).w
+		cmpi.w	#boss_fz_x-$150,(v_screenposx).w
 		bcs.s	loc_7312
 		bsr.w	FindFreeObj
 		bne.s	loc_7312
@@ -689,7 +689,7 @@ loc_7312:
 ; ===========================================================================
 
 DLE_FZend:
-		cmpi.w	#$2450,(v_screenposx).w
+		cmpi.w	#boss_fz_x,(v_screenposx).w
 		bcs.s	loc_7320
 		addq.b	#2,(v_dle_routine).w
 

--- a/_incObj/3D Boss - Green Hill (part 1).asm
+++ b/_incObj/3D Boss - Green Hill (part 1).asm
@@ -74,7 +74,7 @@ BGHZ_ShipIndex:	dc.w BGHZ_ShipStart-BGHZ_ShipIndex
 BGHZ_ShipStart:
 		move.w	#$100,obVelY(a0) ; move ship down
 		bsr.w	BossMove
-		cmpi.w	#$338,$38(a0)
+		cmpi.w	#boss_ghz_y+$38,$38(a0)
 		bne.s	loc_177E6
 		move.w	#0,obVelY(a0)	; stop ship
 		addq.b	#2,ob2ndRout(a0) ; goto next routine

--- a/_incObj/3D Boss - Green Hill (part 2).asm
+++ b/_incObj/3D Boss - Green Hill (part 2).asm
@@ -3,7 +3,7 @@ BGHZ_MakeBall:
 		move.w	#-$100,obVelX(a0)
 		move.w	#-$40,obVelY(a0)
 		bsr.w	BossMove
-		cmpi.w	#$2A00,$30(a0)
+		cmpi.w	#boss_ghz_x+$A0,$30(a0)
 		bne.s	loc_17916
 		move.w	#0,obVelX(a0)
 		move.w	#0,obVelY(a0)
@@ -26,11 +26,11 @@ BGHZ_ShipMove:
 		subq.w	#1,$3C(a0)
 		bpl.s	BGHZ_Reverse
 		addq.b	#2,ob2ndRout(a0)
-		move.w	#$3F,$3C(a0)
+		move.w	#$40-1,$3C(a0)
 		move.w	#$100,obVelX(a0) ; move the ship sideways
-		cmpi.w	#$2A00,$30(a0)
+		cmpi.w	#boss_ghz_x+$A0,$30(a0)
 		bne.s	BGHZ_Reverse
-		move.w	#$7F,$3C(a0)
+		move.w	#($40*2)-1,$3C(a0)
 		move.w	#$40,obVelX(a0)
 
 BGHZ_Reverse:
@@ -51,7 +51,7 @@ loc_17954:
 
 loc_17960:
 		bchg	#0,obStatus(a0)
-		move.w	#$3F,$3C(a0)
+		move.w	#$40-1,$3C(a0)
 		subq.b	#2,ob2ndRout(a0)
 		move.w	#0,obVelX(a0)
 
@@ -120,7 +120,7 @@ loc_179EE:
 loc_179F6:
 		move.w	#$400,obVelX(a0)
 		move.w	#-$40,obVelY(a0)
-		cmpi.w	#$2AC0,(v_limitright2).w
+		cmpi.w	#boss_ghz_end,(v_limitright2).w
 		beq.s	loc_17A10
 		addq.w	#2,(v_limitright2).w
 		bra.s	loc_17A16
@@ -146,7 +146,7 @@ BGHZ_FaceMain:	; Routine 4
 		move.b	ob2ndRout(a1),d0
 		subq.b	#4,d0
 		bne.s	loc_17A3E
-		cmpi.w	#$2A00,$30(a1)
+		cmpi.w	#boss_ghz_x+$A0,$30(a1)
 		bne.s	loc_17A46
 		moveq	#4,d1
 

--- a/_incObj/73 Boss - Marble.asm
+++ b/_incObj/73 Boss - Marble.asm
@@ -79,7 +79,7 @@ loc_18302:
 		move.w	d0,obVelY(a0)
 		move.w	#-$100,obVelX(a0)
 		bsr.w	BossMove
-		cmpi.w	#$1910,$30(a0)
+		cmpi.w	#boss_mz_x+$110,$30(a0)
 		bne.s	loc_18334
 		addq.b	#2,ob2ndRout(a0)
 		clr.b	obSubtype(a0)
@@ -148,7 +148,7 @@ loc_183CA:
 		tst.w	obVelX(a0)
 		bne.s	loc_183FE
 		moveq	#$40,d0
-		cmpi.w	#$22C,$38(a0)
+		cmpi.w	#boss_mz_y+$1C,$38(a0)
 		beq.s	loc_183E6
 		bcs.s	loc_183DE
 		neg.w	d0
@@ -177,12 +177,12 @@ Obj73_MakeLava:
 		jsr	(FindFreeObj).l
 		bne.s	loc_1844A
 		_move.b	#id_LavaBall,0(a1) ; load lava ball object
-		move.w	#$2E8,obY(a1)	; set Y	position
+		move.w	#boss_mz_y+$D8,obY(a1)	; set Y	position
 		jsr	(RandomNumber).l
 		andi.l	#$FFFF,d0
 		divu.w	#$50,d0
 		swap	d0
-		addi.w	#$1878,d0
+		addi.w	#boss_mz_x+$78,d0
 		move.w	d0,obX(a1)
 		lsr.b	#7,d1
 		move.w	#$FF,obSubtype(a1)
@@ -196,21 +196,21 @@ loc_1844A:
 loc_1845C:
 		btst	#0,obStatus(a0)
 		beq.s	loc_18474
-		cmpi.w	#$1910,$30(a0)
+		cmpi.w	#boss_mz_x+$110,$30(a0)
 		blt.s	locret_1849C
-		move.w	#$1910,$30(a0)
+		move.w	#boss_mz_x+$110,$30(a0)
 		bra.s	loc_18482
 ; ===========================================================================
 
 loc_18474:
-		cmpi.w	#$1830,$30(a0)
+		cmpi.w	#boss_mz_x+$30,$30(a0)
 		bgt.s	locret_1849C
-		move.w	#$1830,$30(a0)
+		move.w	#boss_mz_x+$30,$30(a0)
 
 loc_18482:
 		clr.w	obVelX(a0)
 		move.w	#-$180,obVelY(a0)
-		cmpi.w	#$22C,$38(a0)
+		cmpi.w	#boss_mz_y+$1C,$38(a0)
 		bcc.s	loc_18498
 		neg.w	obVelY(a0)
 
@@ -224,9 +224,9 @@ locret_1849C:
 Obj73_MakeLava2:
 		bsr.w	BossMove
 		move.w	$38(a0),d0
-		subi.w	#$22C,d0
+		subi.w	#boss_mz_y+$1C,d0
 		bgt.s	locret_184F4
-		move.w	#$22C,d0
+		move.w	#boss_mz_y+$1C,d0
 		tst.w	obVelY(a0)
 		beq.s	loc_184EA
 		clr.w	obVelY(a0)
@@ -274,7 +274,7 @@ loc_1852C:
 		addq.w	#1,$3C(a0)
 		beq.s	loc_18544
 		bpl.s	loc_1854E
-		cmpi.w	#$270,$38(a0)
+		cmpi.w	#boss_mz_y+$60,$38(a0)
 		bcc.s	loc_18544
 		addi.w	#$18,obVelY(a0)
 		bra.s	loc_1857A
@@ -314,7 +314,7 @@ loc_1857A:
 loc_18582:
 		move.w	#$500,obVelX(a0)
 		move.w	#-$40,obVelY(a0)
-		cmpi.w	#$1960,(v_limitright2).w
+		cmpi.w	#boss_mz_end,(v_limitright2).w
 		bcc.s	loc_1859C
 		addq.w	#2,(v_limitright2).w
 		bra.s	loc_185A2

--- a/_incObj/74 MZ Boss Fire.asm
+++ b/_incObj/74 MZ Boss Fire.asm
@@ -45,7 +45,7 @@ Obj74_Action:	; Routine 2
 		jsr	(SpeedToPos).l
 		lea	(Ani_Fire).l,a1
 		jsr	(AnimateSprite).l
-		cmpi.w	#$2E8,obY(a0)
+		cmpi.w	#boss_mz_y+$D8,obY(a0)
 		bhi.s	Obj74_Delete
 		rts	
 ; ===========================================================================
@@ -126,7 +126,7 @@ Obj74_Duplicate:
 		tst.w	d1
 		bpl.s	loc_18826
 		move.w	obX(a0),d0
-		cmpi.w	#$1940,d0
+		cmpi.w	#boss_mz_x+$140,d0
 		bgt.s	loc_1882C
 		move.w	$30(a0),d1
 		cmp.w	d0,d1

--- a/_incObj/75 Boss - Spring Yard.asm
+++ b/_incObj/75 Boss - Spring Yard.asm
@@ -21,8 +21,8 @@ Obj75_ObjData:	dc.b 2,	0, 5		; routine number, animation, priority
 ; ===========================================================================
 
 Obj75_Main:	; Routine 0
-		move.w	#$2DB0,obX(a0)
-		move.w	#$4DA,obY(a0)
+		move.w	#boss_syz_x+$1B0,obX(a0)
+		move.w	#boss_syz_y+$E,obY(a0)
 		move.w	obX(a0),$30(a0)
 		move.w	obY(a0),$38(a0)
 		move.b	#$F,obColType(a0)
@@ -73,7 +73,7 @@ Obj75_ShipIndex:dc.w loc_191CC-Obj75_ShipIndex,	loc_19270-Obj75_ShipIndex
 
 loc_191CC:
 		move.w	#-$100,obVelX(a0)
-		cmpi.w	#$2D38,$30(a0)
+		cmpi.w	#boss_syz_x+$138,$30(a0)
 		bcc.s	loc_191DE
 		addq.b	#2,ob2ndRout(a0)
 
@@ -90,8 +90,8 @@ loc_191F2:
 		move.w	$30(a0),obX(a0)
 
 loc_19202:
-		move.w	8(a0),d0
-		subi.w	#$2C00,d0
+		move.w	obX(a0),d0
+		subi.w	#boss_syz_x,d0
 		lsr.w	#5,d0
 		move.b	d0,$34(a0)
 		cmpi.b	#6,ob2ndRout(a0)
@@ -138,13 +138,13 @@ loc_19270:
 		btst	#0,obStatus(a0)
 		bne.s	loc_1928E
 		neg.w	obVelX(a0)
-		cmpi.w	#$2C08,d0
+		cmpi.w	#boss_syz_x+8,d0
 		bgt.s	loc_1929E
 		bra.s	loc_19294
 ; ===========================================================================
 
 loc_1928E:
-		cmpi.w	#$2D38,d0
+		cmpi.w	#boss_syz_x+$138,d0
 		blt.s	loc_1929E
 
 loc_19294:
@@ -152,7 +152,7 @@ loc_19294:
 		clr.b	standonobject(a0)
 
 loc_1929E:
-		subi.w	#$2C10,d0
+		subi.w	#boss_syz_x+$10,d0
 		andi.w	#$1F,d0
 		subi.w	#$1F,d0
 		bpl.s	loc_192AE
@@ -164,14 +164,14 @@ loc_192AE:
 		tst.b	standonobject(a0)
 		bne.s	loc_192E8
 		move.w	(v_player+obX).w,d1
-		subi.w	#$2C00,d1
+		subi.w	#boss_syz_x,d1
 		asr.w	#5,d1
 		cmp.b	$34(a0),d1
 		bne.s	loc_192E8
 		moveq	#0,d0
 		move.b	$34(a0),d0
 		asl.w	#5,d0
-		addi.w	#$2C10,d0
+		addi.w	#boss_syz_x+$10,d0
 		move.w	d0,$30(a0)
 		bsr.w	Obj75_FindBlocks
 		addq.b	#2,ob2ndRout(a0)
@@ -197,9 +197,9 @@ off_192FA:	dc.w loc_19302-off_192FA
 loc_19302:
 		move.w	#$180,obVelY(a0)
 		move.w	$38(a0),d0
-		cmpi.w	#$556,d0
+		cmpi.w	#boss_syz_y+$8A,d0
 		bcs.s	loc_19344
-		move.w	#$556,$38(a0)
+		move.w	#boss_syz_y+$8A,$38(a0)
 		clr.w	$3C(a0)
 		moveq	#-1,d0
 		move.w	$36(a0),d0
@@ -249,7 +249,7 @@ loc_1937C:
 ; ===========================================================================
 
 loc_1938E:
-		move.w	#$4DA,d0
+		move.w	#boss_syz_y+$E,d0
 		tst.w	$36(a0)
 		beq.s	loc_1939C
 		subi.w	#$18,d0
@@ -308,7 +308,7 @@ loc_19406:
 		moveq	#2,d0
 
 loc_19410:
-		cmpi.w	#$4DA,$38(a0)
+		cmpi.w	#boss_syz_y+$E,$38(a0)
 		beq.s	loc_19424
 		blt.s	loc_1941C
 		neg.w	d0
@@ -424,7 +424,7 @@ loc_194EE:
 loc_194F2:
 		move.w	#$400,obVelX(a0)
 		move.w	#-$40,obVelY(a0)
-		cmpi.w	#$2D40,(v_limitright2).w
+		cmpi.w	#boss_syz_end,(v_limitright2).w
 		bcc.s	loc_1950C
 		addq.w	#2,(v_limitright2).w
 		bra.s	loc_19512

--- a/_incObj/76 SYZ Boss Blocks.asm
+++ b/_incObj/76 SYZ Boss Blocks.asm
@@ -15,7 +15,7 @@ Obj76_Index:	dc.w Obj76_Main-Obj76_Index
 
 Obj76_Main:	; Routine 0
 		moveq	#0,d4
-		move.w	#$2C10,d5
+		move.w	#boss_syz_x+$10,d5
 		moveq	#9,d6
 		lea	(a0),a1
 		bra.s	Obj76_MakeBlock

--- a/_incObj/77 Boss - Labyrinth.asm
+++ b/_incObj/77 Boss - Labyrinth.asm
@@ -19,8 +19,8 @@ Obj77_ObjData:	dc.b 2,	0		; routine number, animation
 ; ===========================================================================
 
 Obj77_Main:	; Routine 0
-		move.w	#$1E10,obX(a0)
-		move.w	#$5C0,obY(a0)
+		move.w	#boss_lz_x+$30,obX(a0)
+		move.w	#boss_lz_y+$500,obY(a0)
 		move.w	obX(a0),$30(a0)
 		move.w	obY(a0),$38(a0)
 		move.b	#$F,obColType(a0)
@@ -74,7 +74,7 @@ Obj77_ShipIndex:dc.w loc_17F1E-Obj77_ShipIndex,	loc_17FA0-Obj77_ShipIndex
 
 loc_17F1E:
 		move.w	obX(a1),d0
-		cmpi.w	#$1DA0,d0
+		cmpi.w	#boss_lz_x-$40,d0
 		bcs.s	loc_17F38
 		move.w	#-$180,obVelY(a0)
 		move.w	#$60,obVelX(a0)
@@ -128,16 +128,16 @@ loc_17F92:
 
 loc_17FA0:
 		moveq	#-2,d0
-		cmpi.w	#$1E48,$30(a0)
+		cmpi.w	#boss_lz_x+$68,$30(a0)
 		bcs.s	loc_17FB6
-		move.w	#$1E48,$30(a0)
+		move.w	#boss_lz_x+$68,$30(a0)
 		clr.w	obVelX(a0)
 		addq.w	#1,d0
 
 loc_17FB6:
-		cmpi.w	#$500,$38(a0)
+		cmpi.w	#boss_lz_y+$440,$38(a0)
 		bgt.s	loc_17FCA
-		move.w	#$500,$38(a0)
+		move.w	#boss_lz_y+$440,$38(a0)
 		clr.w	obVelY(a0)
 		addq.w	#1,d0
 
@@ -153,16 +153,16 @@ loc_17FDC:
 
 loc_17FE0:
 		moveq	#-2,d0
-		cmpi.w	#$1E70,$30(a0)
+		cmpi.w	#boss_lz_x+$90,$30(a0)
 		bcs.s	loc_17FF6
-		move.w	#$1E70,$30(a0)
+		move.w	#boss_lz_x+$90,$30(a0)
 		clr.w	obVelX(a0)
 		addq.w	#1,d0
 
 loc_17FF6:
-		cmpi.w	#$4C0,$38(a0)
+		cmpi.w	#boss_lz_y+$400,$38(a0)
 		bgt.s	loc_1800A
-		move.w	#$4C0,$38(a0)
+		move.w	#boss_lz_y+$400,$38(a0)
 		clr.w	obVelY(a0)
 		addq.w	#1,d0
 
@@ -177,9 +177,9 @@ loc_1801A:
 ; ===========================================================================
 
 loc_1801E:
-		cmpi.w	#$100,$38(a0)
+		cmpi.w	#boss_lz_y+$40,$38(a0)
 		bgt.s	loc_1804E
-		move.w	#$100,$38(a0)
+		move.w	#boss_lz_y+$40,$38(a0)
 		move.w	#$140,obVelX(a0)
 		move.w	#-$80,obVelY(a0)
 		tst.b	standonobject(a0)
@@ -237,16 +237,16 @@ loc_180AE:
 
 loc_180BC:
 		moveq	#-2,d0
-		cmpi.w	#$1F4C,$30(a0)
+		cmpi.w	#boss_lz_x+$16C,$30(a0)
 		bcs.s	loc_180D2
-		move.w	#$1F4C,$30(a0)
+		move.w	#boss_lz_x+$16C,$30(a0)
 		clr.w	obVelX(a0)
 		addq.w	#1,d0
 
 loc_180D2:
-		cmpi.w	#$C0,$38(a0)
+		cmpi.w	#boss_lz_y,$38(a0)
 		bgt.s	loc_180E6
-		move.w	#$C0,$38(a0)
+		move.w	#boss_lz_y,$38(a0)
 		clr.w	obVelY(a0)
 		addq.w	#1,d0
 
@@ -262,9 +262,9 @@ loc_180F2:
 loc_180F6:
 		tst.b	standonobject(a0)
 		bne.s	loc_18112
-		cmpi.w	#$1EC8,obX(a1)
+		cmpi.w	#boss_lz_x+$E8,obX(a1)
 		blt.s	loc_18126
-		cmpi.w	#$F0,obY(a1)
+		cmpi.w	#boss_lz_y+$30,obY(a1)
 		bgt.s	loc_18126
 		move.b	#$32,$3C(a0)
 
@@ -299,7 +299,7 @@ loc_1814E:
 ; ===========================================================================
 
 loc_18152:
-		cmpi.w	#$2030,(v_limitright2).w
+		cmpi.w	#boss_lz_end,(v_limitright2).w
 		bcc.s	loc_18160
 		addq.w	#2,(v_limitright2).w
 		bra.s	loc_18166

--- a/_incObj/7A Boss - Star Light.asm
+++ b/_incObj/7A Boss - Star Light.asm
@@ -21,8 +21,8 @@ Obj7A_ObjData:	dc.b 2,	0, 4		; routine number, animation, priority
 ; ===========================================================================
 
 Obj7A_Main:
-		move.w	#$2188,obX(a0)
-		move.w	#$228,obY(a0)
+		move.w	#boss_slz_x+$188,obX(a0)
+		move.w	#boss_slz_y+$18,obY(a0)
 		move.w	obX(a0),$30(a0)
 		move.w	obY(a0),$38(a0)
 		move.b	#$F,obColType(a0)
@@ -93,7 +93,7 @@ Obj7A_ShipIndex:dc.w loc_189B8-Obj7A_ShipIndex
 
 loc_189B8:
 		move.w	#-$100,obVelX(a0)
-		cmpi.w	#$2120,$30(a0)
+		cmpi.w	#boss_slz_x+$120,$30(a0)
 		bcc.s	loc_189CA
 		addq.b	#2,ob2ndRout(a0)
 
@@ -159,13 +159,13 @@ loc_18A5E:
 		btst	#0,obStatus(a0)
 		bne.s	loc_18A7C
 		neg.w	obVelX(a0)
-		cmpi.w	#$2008,d0
+		cmpi.w	#boss_slz_x+8,d0
 		bgt.s	loc_18A88
 		bra.s	loc_18A82
 ; ===========================================================================
 
 loc_18A7C:
-		cmpi.w	#$2138,d0
+		cmpi.w	#boss_slz_x+$138,d0
 		blt.s	loc_18A88
 
 loc_18A82:
@@ -311,7 +311,7 @@ loc_18BC2:
 loc_18BC6:
 		move.w	#$400,obVelX(a0)
 		move.w	#-$40,obVelY(a0)
-		cmpi.w	#$2160,(v_limitright2).w
+		cmpi.w	#boss_slz_end,(v_limitright2).w
 		bcc.s	loc_18BE0
 		addq.w	#2,(v_limitright2).w
 		bra.s	loc_18BE8

--- a/_incObj/7B SLZ Boss Spikeball.asm
+++ b/_incObj/7B SLZ Boss Spikeball.asm
@@ -184,8 +184,8 @@ loc_18EC0:
 		move.w	obY(a1),d1
 		move.w	obX(a0),d2
 		move.w	obY(a0),d3
-		lea	byte_19022(pc),a2
-		lea	byte_19026(pc),a3
+		lea	Obj7B_BossHitbox(pc),a2
+		lea	Obj7B_BallHitbox(pc),a3
 		move.b	(a2)+,d4
 		ext.w	d4
 		add.w	d4,d0
@@ -303,9 +303,13 @@ loc_19008:
 ; ===========================================================================
 word_19018:	dc.w -8, -$1C, -$2F, -$1C, -8
 		even
-byte_19022:	dc.b $E8, $30, $E8, $30
+Obj7B_BossHitbox:
+		dc.b -$18, $18+$18		; left to right
+		dc.b -$18, $18+$18		; top to bottom
 		even
-byte_19026:	dc.b 8,	$F0, 8,	$F0
+Obj7B_BallHitbox:
+		dc.b 8,	-8-8			; right to left
+		dc.b 8, -8-8			; bottom to top
 		even
 ; ===========================================================================
 

--- a/_incObj/82 Eggman - Scrap Brain 2.asm
+++ b/_incObj/82 Eggman - Scrap Brain 2.asm
@@ -18,8 +18,8 @@ SEgg_ObjData:	dc.b 2,	0, 3		; routine number, animation, priority
 
 SEgg_Main:	; Routine 0
 		lea	SEgg_ObjData(pc),a2
-		move.w	#$2160,obX(a0)
-		move.w	#$5A4,obY(a0)
+		move.w	#boss_sbz2_x+$110,obX(a0)
+		move.w	#boss_sbz2_y+$94,obY(a0)
 		move.b	#$F,obColType(a0)
 		move.b	#$10,obColProp(a0)
 		bclr	#0,obStatus(a0)
@@ -36,8 +36,8 @@ SEgg_Main:	; Routine 0
 		bne.s	SEgg_Eggman
 		move.l	a0,$34(a1)
 		move.b	#id_ScrapEggman,(a1) ; load switch object
-		move.w	#$2130,obX(a1)
-		move.w	#$5BC,obY(a1)
+		move.w	#boss_sbz2_x+$E0,obX(a1)
+		move.w	#boss_sbz2_y+$AC,obY(a1)
 		clr.b	ob2ndRout(a0)
 		move.b	(a2)+,obRoutine(a1)
 		move.b	(a2)+,obAnim(a1)
@@ -97,7 +97,7 @@ SEgg_Leap:
 		move.w	#-$3C0,obVelY(a0)
 
 loc_1996A:
-		cmpi.w	#$2132,obX(a0)
+		cmpi.w	#boss_sbz2_x+$E2,obX(a0)
 		bgt.s	loc_19976
 		clr.w	obVelX(a0)
 
@@ -105,12 +105,12 @@ loc_19976:
 		addi.w	#$24,obVelY(a0)
 		tst.w	obVelY(a0)
 		bmi.s	SEgg_FindBlocks
-		cmpi.w	#$595,obY(a0)
+		cmpi.w	#boss_sbz2_y+$85,obY(a0)
 		bcs.s	SEgg_FindBlocks
-		move.w	#$5357,obSubtype(a0)
-		cmpi.w	#$59B,obY(a0)
+		move.w	#"SW",obSubtype(a0)
+		cmpi.w	#boss_sbz2_y+$8B,obY(a0)
 		bcs.s	SEgg_FindBlocks
-		move.w	#$59B,obY(a0)
+		move.w	#boss_sbz2_y+$8B,obY(a0)
 		clr.w	obVelY(a0)
 
 SEgg_FindBlocks:
@@ -127,7 +127,7 @@ SEgg_FindLoop:
 		dbeq	d0,SEgg_FindLoop ; if not, repeat (max	$3E times)
 
 		bne.s	loc_199D0
-		move.w	#$474F,obSubtype(a1) ; set block to disintegrate
+		move.w	#"GO",obSubtype(a1) ; set block to disintegrate
 		addq.b	#2,ob2ndRout(a0)
 		move.b	#1,obAnim(a0)
 
@@ -147,7 +147,7 @@ SEgg_SwIndex:	dc.w loc_199E6-SEgg_SwIndex
 
 loc_199E6:
 		movea.l	$34(a0),a1
-		cmpi.w	#$5357,obSubtype(a1)
+		cmpi.w	#"SW",obSubtype(a1)
 		bne.s	SEgg_SwDisplay
 		move.b	#1,obFrame(a0)
 		addq.b	#2,ob2ndRout(a0)

--- a/_incObj/83 SBZ Eggman's Crumbling Floor.asm
+++ b/_incObj/83 SBZ Eggman's Crumbling Floor.asm
@@ -17,14 +17,14 @@ FFloor_Index:	dc.w FFloor_Main-FFloor_Index
 ; ===========================================================================
 
 FFloor_Main:	; Routine 0
-		move.w	#$2080,obX(a0)
-		move.w	#$5D0,obY(a0)
+		move.w	#boss_sbz2_x+$30,obX(a0)
+		move.w	#boss_sbz2_y+$C0,obY(a0)
 		move.b	#$80,obActWid(a0)
 		move.b	#$10,obHeight(a0)
 		move.b	#4,obRender(a0)
 		bset	#7,obRender(a0)
 		moveq	#0,d4
-		move.w	#$2010,d5
+		move.w	#boss_sbz2_x-$40,d5
 		moveq	#7,d6
 		lea	$30(a0),a2
 
@@ -40,7 +40,7 @@ FFloor_MakeBlock:
 		move.b	#$10,obHeight(a1)
 		move.b	#3,obPriority(a1)
 		move.w	d5,obX(a1)	; set X	position
-		move.w	#$5D0,obY(a1)
+		move.w	#boss_sbz2_y+$C0,obY(a1)
 		addi.w	#$20,d5		; add $20 for next X position
 		move.b	#8,obRoutine(a1)
 		dbf	d6,FFloor_MakeBlock ; repeat sequence 7 more times
@@ -51,7 +51,7 @@ FFloor_ExitMake:
 ; ===========================================================================
 
 FFloor_ChkBreak:; Routine 2
-		cmpi.w	#$474F,obSubtype(a0) ; is object set to disintegrate?
+		cmpi.w	#"GO",obSubtype(a0) ; is object set to disintegrate?
 		bne.s	FFloor_Solid	; if not, branch
 		clr.b	obFrame(a0)
 		addq.b	#2,obRoutine(a0) ; next subroutine
@@ -63,7 +63,7 @@ FFloor_Solid:
 		ext.w	d0
 		addq.w	#8,d0
 		asl.w	#4,d0
-		move.w	#$2100,d4
+		move.w	#boss_sbz2_x+$B0,d4
 		sub.w	d0,d4
 		move.b	d0,obActWid(a0)
 		move.w	d4,obX(a0)
@@ -83,7 +83,7 @@ loc_19C36:	; Routine 4
 		add.w	d0,d0
 		move.w	$30(a0,d0.w),d0
 		movea.l	d0,a1
-		move.w	#$474F,obSubtype(a1)
+		move.w	#"GO",obSubtype(a1)
 		addq.b	#1,obFrame(a0)
 		cmpi.b	#8,obFrame(a0)
 		beq.s	loc_19C62
@@ -99,7 +99,7 @@ loc_19C62:	; Routine 6
 ; ===========================================================================
 
 loc_19C72:	; Routine 8
-		cmpi.w	#$474F,obSubtype(a0) ; is object set to disintegrate?
+		cmpi.w	#"GO",obSubtype(a0) ; is object set to disintegrate?
 		beq.s	FFloor_Break	; if yes, branch
 		jmp	(DisplaySprite).l
 ; ===========================================================================

--- a/_incObj/84 FZ Eggman's Cylinders.asm
+++ b/_incObj/84 FZ Eggman's Cylinders.asm
@@ -16,10 +16,10 @@ Obj84_Index:	dc.w Obj84_Main-Obj84_Index
 		dc.w loc_1A4CE-Obj84_Index
 		dc.w loc_1A57E-Obj84_Index
 
-Obj84_PosData:	dc.w $24D0, $620
-		dc.w $2550, $620
-		dc.w $2490, $4C0
-		dc.w $2510, $4C0
+Obj84_PosData:	dc.w boss_fz_x+$80,  boss_fz_y+$110
+		dc.w boss_fz_x+$100, boss_fz_y+$110
+		dc.w boss_fz_x+$40,  boss_fz_y-$50
+		dc.w boss_fz_x+$C0,  boss_fz_y-$50
 ; ===========================================================================
 
 Obj84_Main:	; Routine

--- a/_incObj/85 Boss - Final.asm
+++ b/_incObj/85 Boss - Final.asm
@@ -22,15 +22,15 @@ Obj85_Index:	dc.w Obj85_Main-Obj85_Index
 
 Obj85_ObjData:	dc.w $100, $100, $470	; X pos, Y pos,	VRAM setting
 		dc.l Map_SEgg		; mappings pointer
-		dc.w $25B0, $590, $300
+		dc.w boss_fz_x+$160, boss_fz_y+$80, $300
 		dc.l Map_EggCyl
-		dc.w $26E0, $596, $3A0
+		dc.w boss_fz_x+$290, boss_fz_y+$86, $3A0
 		dc.l Map_FZLegs
-		dc.w $26E0, $596, $470
+		dc.w boss_fz_x+$290, boss_fz_y+$86, $470
 		dc.l Map_SEgg
-		dc.w $26E0, $596, $400
+		dc.w boss_fz_x+$290, boss_fz_y+$86, $400
 		dc.l Map_Eggman
-		dc.w $26E0, $596, $400
+		dc.w boss_fz_x+$290, boss_fz_y+$86, $400
 		dc.l Map_Eggman
 
 Obj85_ObjData2:	dc.b 2,	0, 4, $20, $19	; routine num, animation, sprite priority, width, height
@@ -115,7 +115,7 @@ off_19E80:	dc.w loc_19E90-off_19E80, loc_19EA8-off_19E80
 loc_19E90:
 		tst.l	(v_plc_buffer).w
 		bne.s	loc_19EA2
-		cmpi.w	#$2450,(v_screenposx).w
+		cmpi.w	#boss_fz_x,(v_screenposx).w
 		bcs.s	loc_19EA2
 		addq.b	#2,$34(a0)
 
@@ -227,8 +227,8 @@ loc_19FBC:
 			bsr.w	AddPoints
 		endif
 		move.b	#6,$34(a0)
-		move.w	#$25C0,obX(a0)
-		move.w	#$53C,obY(a0)
+		move.w	#boss_fz_x+$170,obX(a0)
+		move.w	#boss_fz_y+$2C,obY(a0)
 		move.b	#$14,obHeight(a0)
 		rts	
 ; ===========================================================================
@@ -277,9 +277,9 @@ loc_1A02A:
 		jsr	(SpeedToPos).l
 		move.b	#6,obFrame(a0)
 		addi.w	#$10,obVelY(a0)
-		cmpi.w	#$59C,obY(a0)
+		cmpi.w	#boss_fz_y+$8C,obY(a0)
 		bcs.s	loc_1A070
-		move.w	#$59C,obY(a0)
+		move.w	#boss_fz_y+$8C,obY(a0)
 		addq.b	#2,$34(a0)
 		if Revision=0
 		move.b	#$20,obWidth(a0)
@@ -299,7 +299,7 @@ loc_1A074:
 		move.b	#4,obAnim(a0)
 		jsr	(SpeedToPos).l
 		addi.w	#$10,obVelY(a0)
-		cmpi.w	#$5A3,obY(a0)
+		cmpi.w	#boss_fz_y+$93,obY(a0)
 		bcs.s	loc_1A09A
 		move.w	#-$40,obVelY(a0)
 
@@ -333,9 +333,9 @@ loc_1A0B4:
 		clr.w	obVelX(a0)
 
 loc_1A0F2:
-		cmpi.w	#$26A0,obX(a0)
+		cmpi.w	#boss_fz_x+$250,obX(a0)
 		bcs.s	loc_1A110
-		move.w	#$26A0,obX(a0)
+		move.w	#boss_fz_x+$250,obX(a0)
 		move.w	#$240,obVelX(a0)
 		move.w	#-$4C0,obVelY(a0)
 		addq.b	#2,$34(a0)
@@ -346,7 +346,7 @@ loc_1A110:
 
 loc_1A112:
 		jsr	(SpeedToPos).l
-		cmpi.w	#$26E0,obX(a0)
+		cmpi.w	#boss_fz_x+$290,obX(a0)
 		bcs.s	loc_1A124
 		clr.w	obVelX(a0)
 
@@ -354,9 +354,9 @@ loc_1A124:
 		addi.w	#$34,obVelY(a0)
 		tst.w	obVelY(a0)
 		bmi.s	loc_1A142
-		cmpi.w	#$592,obY(a0)
+		cmpi.w	#boss_fz_y+$82,obY(a0)
 		bcs.s	loc_1A142
-		move.w	#$592,obY(a0)
+		move.w	#boss_fz_y+$82,obY(a0)
 		clr.w	obVelY(a0)
 
 loc_1A142:
@@ -372,7 +372,7 @@ loc_1A15C:
 		jsr	(AnimateSprite).l
 
 loc_1A166:
-		cmpi.w	#$2700,(v_limitright2).w
+		cmpi.w	#boss_fz_end,(v_limitright2).w
 		bge.s	loc_1A172
 		addq.w	#2,(v_limitright2).w
 
@@ -396,7 +396,7 @@ loc_1A192:
 		move.b	#0,obAnim(a0)
 		bset	#0,obStatus(a0)
 		jsr	(SpeedToPos).l
-		cmpi.w	#$544,obY(a0)
+		cmpi.w	#boss_fz_y+$34,obY(a0)
 		bcc.s	loc_1A1D0
 		move.w	#$180,obVelX(a0)
 		move.w	#-$18,obVelY(a0)
@@ -431,7 +431,7 @@ loc_1A210:
 		move.b	#$F,obColType(a0)
 
 loc_1A216:
-		cmpi.w	#$2790,(v_player+obX).w
+		cmpi.w	#boss_fz_end+$90,(v_player+obX).w
 		blt.s	loc_1A23A
 		move.b	#1,(f_lockctrl).w
 		move.w	#0,(v_jpadhold2).w
@@ -441,12 +441,12 @@ loc_1A216:
 		move.w	#$100,(v_jpadhold2).w
 
 loc_1A23A:
-		cmpi.w	#$27E0,(v_player+obX).w
+		cmpi.w	#boss_fz_end+$E0,(v_player+obX).w
 		blt.s	loc_1A248
-		move.w	#$27E0,(v_player+obX).w
+		move.w	#boss_fz_end+$E0,(v_player+obX).w
 
 loc_1A248:
-		cmpi.w	#$2900,obX(a0)
+		cmpi.w	#boss_fz_end+$200,obX(a0)
 		bcs.s	loc_1A260
 		tst.b	obRender(a0)
 		bmi.s	loc_1A260

--- a/_incObj/86 FZ Plasma Ball Launcher.asm
+++ b/_incObj/86 FZ Plasma Ball Launcher.asm
@@ -16,8 +16,8 @@ Obj86_Index:	dc.w Obj86_Main-Obj86_Index
 ; ===========================================================================
 
 Obj86_Main:	; Routine 0
-		move.w	#$2588,obX(a0)
-		move.w	#$53C,obY(a0)
+		move.w	#boss_fz_x+$138,obX(a0)
+		move.w	#boss_fz_y+$2C,obY(a0)
 		move.w	#$300,obGfx(a0)
 		move.l	#Map_PLaunch,obMap(a0)
 		move.b	#0,obAnim(a0)
@@ -81,7 +81,7 @@ Obj86_Loop:
 		bne.w	loc_1A954
 		move.b	#id_BossPlasma,(a1)
 		move.w	obX(a0),obX(a1)
-		move.w	#$53C,obY(a1)
+		move.w	#boss_fz_y+$2C,obY(a1)
 		move.b	#8,obRoutine(a1)
 		move.w	#$2300,obGfx(a1)
 		move.l	#Map_Plasma,obMap(a1)
@@ -96,7 +96,7 @@ Obj86_Loop:
 		jsr	(RandomNumber).l
 		move.w	$32(a0),d1
 		muls.w	#-$4F,d1
-		addi.w	#$2578,d1
+		addi.w	#boss_fz_x+$128,d1
 		andi.w	#$1F,d0
 		subi.w	#$10,d0
 		add.w	d1,d0
@@ -182,7 +182,7 @@ locret_1AA1C:
 
 loc_1AA1E:
 		jsr	(SpeedToPos).l
-		cmpi.w	#$5E0,obY(a0)
+		cmpi.w	#boss_fz_y+$D0,obY(a0)
 		bcc.s	loc_1AA34
 		subq.w	#1,obSubtype(a0)
 		beq.s	loc_1AA34

--- a/build.lua
+++ b/build.lua
@@ -15,7 +15,23 @@ local improved_dac_driver_compression = false
 
 local common = require "build_tools.lua.common"
 
-os.exit(common.build_rom("sonic", "s1built", "", "-p=FF -z=0," .. (improved_dac_driver_compression and "kosinski-optimised" or "kosinski") .. ",Size_of_DAC_driver_guess,after", false, "https://github.com/sonicretro/s1disasm"))
+local exit_code
+local repository = "https://github.com/sonicretro/s1disasm"
+
+local function success_continue_wrapper(success, continue)
+	if not success then
+		exit_code = false
+	end
+
+	if not continue then
+		os.exit(false)
+	end
+end
+
+success_continue_wrapper(common.build_rom("sonic", "s1built", "", "-p=FF -z=0," .. (improved_dac_driver_compression and "kosinski-optimised" or "kosinski") .. ",Size_of_DAC_driver_guess,after", false, repository))
 
 -- Correct the ROM's header with a proper checksum and end-of-ROM value.
 common.fix_header("s1built.bin")
+
+-- A successful build; we can quit now.
+os.exit(exit_code)


### PR DESCRIPTION
The values used are based on where the camera boundaries are situated at and how each boss moves. For Labyrinth Zone, it's based on the corridor's boundaries. Comments and suggestions about the values chosen are welcome. This should help make it a bit more clear about how the boss moves around and help make repositioning them in hacks easier to deal with. The positions where the camera scrolls towards after the bosses are defeated are also included. This was mainly made to address this [post](https://forums.sonicretro.org/index.php?threads/md-gen-sonic-camera-and-hud-manipulation.41823/) on Sonic Retro.

I also fixed the build script, because it wasn't actually continuing to fix the ROM header after building, since the return value from it was being used for os.exit(). I ported over the method of handling that from the Sonic 2 disassembly.

Also, a few other tiny changes regarding a missing SST label and label changes in the SLZ boss.