### PR TITLE
Better names for palette load routines.

### DIFF
--- a/sonic.asm
+++ b/sonic.asm
@@ -1890,7 +1890,7 @@ Pal_Sega2:	binclude	"palette/Sega2.bin"
 ; ||||||||||||||| S U B	R O U T	I N E |||||||||||||||||||||||||||||||||||||||
 
 
-PalLoad1:
+PalLoad_Fade:
 		lea	(PalPointers).l,a1
 		lsl.w	#3,d0
 		adda.w	d0,a1
@@ -1903,13 +1903,13 @@ PalLoad1:
 		move.l	(a2)+,(a3)+	; move data to RAM
 		dbf	d7,.loop
 		rts	
-; End of function PalLoad1
+; End of function PalLoad_Fade
 
 
 ; ||||||||||||||| S U B	R O U T	I N E |||||||||||||||||||||||||||||||||||||||
 
 
-PalLoad2:
+PalLoad:
 		lea	(PalPointers).l,a1
 		lsl.w	#3,d0
 		adda.w	d0,a1
@@ -1921,7 +1921,7 @@ PalLoad2:
 		move.l	(a2)+,(a3)+	; move data to RAM
 		dbf	d7,.loop
 		rts	
-; End of function PalLoad2
+; End of function PalLoad
 
 ; ---------------------------------------------------------------------------
 ; Underwater palette loading subroutine
@@ -1930,7 +1930,7 @@ PalLoad2:
 ; ||||||||||||||| S U B	R O U T	I N E |||||||||||||||||||||||||||||||||||||||
 
 
-PalLoad3_Water:
+PalLoad_Fade_Water:
 		lea	(PalPointers).l,a1
 		lsl.w	#3,d0
 		adda.w	d0,a1
@@ -1943,13 +1943,13 @@ PalLoad3_Water:
 		move.l	(a2)+,(a3)+	; move data to RAM
 		dbf	d7,.loop
 		rts	
-; End of function PalLoad3_Water
+; End of function PalLoad_Fade_Water
 
 
 ; ||||||||||||||| S U B	R O U T	I N E |||||||||||||||||||||||||||||||||||||||
 
 
-PalLoad4_Water:
+PalLoad_Water:
 		lea	(PalPointers).l,a1
 		lsl.w	#3,d0
 		adda.w	d0,a1
@@ -1962,7 +1962,7 @@ PalLoad4_Water:
 		move.l	(a2)+,(a3)+	; move data to RAM
 		dbf	d7,.loop
 		rts	
-; End of function PalLoad4_Water
+; End of function PalLoad_Water
 
 ; ===========================================================================
 
@@ -2056,7 +2056,7 @@ GM_Sega:
 
 .loadpal:
 		moveq	#palid_SegaBG,d0
-		bsr.w	PalLoad2	; load Sega logo palette
+		bsr.w	PalLoad	; load Sega logo palette
 		move.w	#-$A,(v_pcyc_num).w
 		move.w	#0,(v_pcyc_time).w
 		move.w	#0,(v_pal_buffer+$12).w
@@ -2130,7 +2130,7 @@ GM_Title:
 		clearRAM v_pal_dry_dup,v_pal_dry_dup+16*4*2
 
 		moveq	#palid_Sonic,d0	; load Sonic's palette
-		bsr.w	PalLoad1
+		bsr.w	PalLoad_Fade
 		move.b	#id_CreditsText,(v_sonicteam).w ; load "SONIC TEAM PRESENTS" object
 		jsr	(ExecuteObjects).l
 		jsr	(BuildSprites).l
@@ -2190,7 +2190,7 @@ Tit_LoadText:
 		lea	(Nem_GHZ_1st).l,a0 ; load GHZ patterns
 		bsr.w	NemDec
 		moveq	#palid_Title,d0	; load title screen palette
-		bsr.w	PalLoad1
+		bsr.w	PalLoad_Fade
 		move.b	#bgm_Title,d0
 		bsr.w	PlaySound_Special	; play title screen music
 		move.b	#0,(f_debugmode).w ; disable debug mode
@@ -2312,7 +2312,7 @@ Tit_ChkLevSel:
 		beq.w	PlayLevel	; if not, play level
 
 		moveq	#palid_LevelSel,d0
-		bsr.w	PalLoad2	; load level select palette
+		bsr.w	PalLoad	; load level select palette
 
 		clearRAM v_hscrolltablebuffer,v_hscrolltablebuffer_end
 
@@ -2813,7 +2813,7 @@ Level_LoadPal:
 		move.w	#30,(v_air).w
 		enable_ints
 		moveq	#palid_Sonic,d0
-		bsr.w	PalLoad2	; load Sonic's palette
+		bsr.w	PalLoad	; load Sonic's palette
 		cmpi.b	#id_LZ,(v_zone).w ; is level LZ?
 		bne.s	Level_GetBgm	; if not, branch
 
@@ -2823,7 +2823,7 @@ Level_LoadPal:
 		moveq	#palid_SBZ3SonWat,d0 ; palette number $10 (SBZ3)
 
 Level_WaterPal:
-		bsr.w	PalLoad3_Water	; load underwater palette
+		bsr.w	PalLoad_Fade_Water	; load underwater palette
 		tst.b	(v_lastlamp).w
 		beq.s	Level_GetBgm
 		move.b	(v_lamp_wtrstat).w,(f_wtr_state).w
@@ -2863,7 +2863,7 @@ Level_TtlCardLoop:
 
 Level_SkipTtlCard:
 		moveq	#palid_Sonic,d0
-		bsr.w	PalLoad1	; load Sonic's palette
+		bsr.w	PalLoad_Fade	; load Sonic's palette
 		bsr.w	LevelSizeLoad
 		bsr.w	DeformLayers
 		bset	#2,(v_fg_scroll_flags).w
@@ -2952,7 +2952,7 @@ Level_ChkWaterPal:
 		moveq	#palid_SBZ3Water,d0 ; palette $D (SBZ3 underwater)
 
 Level_WtrNotSbz:
-		bsr.w	PalLoad4_Water
+		bsr.w	PalLoad_Water
 
 Level_Delay:
 		move.w	#3,d1
@@ -3224,7 +3224,7 @@ GM_Special:
 		clr.b	(f_wtr_state).w
 		clr.w	(f_restart).w
 		moveq	#palid_Special,d0
-		bsr.w	PalLoad1	; load special stage palette
+		bsr.w	PalLoad_Fade	; load special stage palette
 		jsr	(SS_Load).l		; load SS layout data
 		move.l	#0,(v_screenposx).w
 		move.l	#0,(v_screenposy).w
@@ -3326,7 +3326,7 @@ loc_47D4:
 		jsr	(Hud_Base).l
 		enable_ints
 		moveq	#palid_SSResult,d0
-		bsr.w	PalLoad2	; load results screen palette
+		bsr.w	PalLoad	; load results screen palette
 		moveq	#plcid_Main,d0
 		bsr.w	NewPLC
 		moveq	#plcid_SSResult,d0
@@ -3746,7 +3746,7 @@ GM_Continue:
 		moveq	#10,d1
 		jsr	(ContScrCounter).l	; run countdown	(start from 10)
 		moveq	#palid_Continue,d0
-		bsr.w	PalLoad1	; load continue	screen palette
+		bsr.w	PalLoad_Fade	; load continue	screen palette
 		move.b	#bgm_Continue,d0
 		bsr.w	PlaySound	; play continue	music
 		move.w	#659,(v_demolength).w ; set time delay to 11 seconds
@@ -3863,7 +3863,7 @@ End_LoadData:
 		lea	(v_256x256_end-$1000).w,a1 ; RAM address to buffer the patterns
 		bsr.w	KosDec
 		moveq	#palid_Sonic,d0
-		bsr.w	PalLoad1	; load Sonic's palette
+		bsr.w	PalLoad_Fade	; load Sonic's palette
 		move.w	#bgm_Ending,d0
 		bsr.w	PlaySound	; play ending sequence music
 		btst	#bitA,(v_jpadhold1).w ; is button A pressed?
@@ -3968,7 +3968,7 @@ End_SlowFade:
 		move.w	#$4000,d2
 		bsr.w	DrawChunks
 		moveq	#palid_Ending,d0
-		bsr.w	PalLoad1	; load ending palette
+		bsr.w	PalLoad_Fade	; load ending palette
 		bsr.w	PaletteWhiteIn
 		bra.w	End_MainLoop
 
@@ -4059,7 +4059,7 @@ GM_Credits:
 		clearRAM v_pal_dry_dup,v_pal_dry_dup+16*4*2
 
 		moveq	#palid_Sonic,d0
-		bsr.w	PalLoad1	; load Sonic's palette
+		bsr.w	PalLoad_Fade	; load Sonic's palette
 		move.b	#id_CreditsText,(v_credits).w ; load credits object
 		jsr	(ExecuteObjects).l
 		jsr	(BuildSprites).l
@@ -4177,7 +4177,7 @@ TryAgainEnd:
 		clearRAM v_pal_dry_dup,v_pal_dry_dup+16*4*2
 
 		moveq	#palid_Ending,d0
-		bsr.w	PalLoad1	; load ending palette
+		bsr.w	PalLoad_Fade	; load ending palette
 		clr.w	(v_pal_dry_dup+$40).w
 		move.b	#id_EndEggman,(v_endeggman).w ; load Eggman object
 		jsr	(ExecuteObjects).l
@@ -5234,7 +5234,7 @@ LevelDataLoad:
 		moveq	#palid_SBZ2,d0	; use SBZ2/FZ palette
 
 .normalpal:
-		bsr.w	PalLoad1	; load palette (based on d0)
+		bsr.w	PalLoad_Fade	; load palette (based on d0)
 		movea.l	(sp)+,a2
 		addq.w	#4,a2		; read number for 2nd PLC
 		moveq	#0,d0


### PR DESCRIPTION
Instead of having simple numbered names for these routines, I believe it's better to tell what these routines actually do in their name. The changes are as followed:
- `PalLoad1`: Changed to `PalLoad_Fade`, as this loads the palette into a buffer (`v_pal_dry_dup`) that's read from the `PaletteFadeIn` routine. When `PaletteFadeIn` is called, it's copied from `v_pal_dry_dup` into `v_pal_dry`.
- `PalLoad2`: Changed to `PalLoad`, as this directly loads the palette into `v_pal_dry`. `v_pal_dry` is always copied to CRAM in VBLANK.
- `PalLoad3`: Changed to `PalLoad_Fade_Water`. This is the same as `PalLoad1`/`PalLoad_Fade`, but for the underwater palette.
- `PalLoad4`: Changed to `PalLoad_Water`. This is the same as `PalLoad2`/`PalLoad`, but for the underwater palette.

I would additionally suggest changing `v_pal_dry` to simply `v_palette`, given the distinction between the above water and underwater palettes is only useful in Labyrinth Zone. This variable name suggestion is not included in this pull request,