### PR TITLE
Correct names for debug movement variables

### DIFF
--- a/Variables.asm
+++ b/Variables.asm
@@ -308,8 +308,8 @@ v_framebyte = v_framecount+1			; low byte for frame counter
 v_debugitem:		ds.b	1		; debug item currently selected (NOT the object number of the item)
 			ds.b	1		; unused
 v_debuguse:		ds.w	1		; debug mode use & routine counter (when Sonic is a ring/item)
-v_debugxspeed:		ds.b	1		; debug mode - horizontal speed
-v_debugyspeed:		ds.b	1		; debug mode - vertical speed
+v_debugspeedtimer:		ds.b	1		; debug mode - timer before movement starts
+v_debugspeed:		ds.b	1		; debug mode - movement speed
 v_vbla_count:		ds.l	1		; vertical interrupt counter (adds 1 every VBlank)
 v_vbla_word = v_vbla_count+2 			; low word for vertical interrupt counter (2 bytes)
 v_vbla_byte = v_vbla_word+1			; low byte for vertical interrupt counter

--- a/_incObj/DebugMode.asm
+++ b/_incObj/DebugMode.asm
@@ -47,8 +47,8 @@ Debug_Main:	; Routine 0
 
 .noreset:
 		bsr.w	Debug_ShowItem
-		move.b	#12,(v_debugxspeed).w
-		move.b	#1,(v_debugyspeed).w
+		move.b	#12,(v_debugspeedtimer).w
+		move.b	#1,(v_debugspeed).w
 
 Debug_Action:	; Routine 2
 		moveq	#6,d0
@@ -80,25 +80,25 @@ Debug_Control:
 		andi.w	#btnDir,d0	; is up/down/left/right	held?
 		bne.s	.dirheld	; if yes, branch
 
-		move.b	#12,(v_debugxspeed).w
-		move.b	#15,(v_debugyspeed).w
+		move.b	#12,(v_debugspeedtimer).w
+		move.b	#15,(v_debugspeed).w
 		bra.w	Debug_ChgItem
 ; ===========================================================================
 
 .dirheld:
-		subq.b	#1,(v_debugxspeed).w
+		subq.b	#1,(v_debugspeedtimer).w
 		bne.s	loc_1D01C
-		move.b	#1,(v_debugxspeed).w
-		addq.b	#1,(v_debugyspeed).w
+		move.b	#1,(v_debugspeedtimer).w
+		addq.b	#1,(v_debugspeed).w
 		bne.s	.dirpressed
-		move.b	#-1,(v_debugyspeed).w
+		move.b	#-1,(v_debugspeed).w
 
 .dirpressed:
 		move.b	(v_jpadhold1).w,d4
 
 loc_1D01C:
 		moveq	#0,d1
-		move.b	(v_debugyspeed).w,d1
+		move.b	(v_debugspeed).w,d1
 		addq.w	#1,d1
 		swap	d1
 		asr.l	#4,d1


### PR DESCRIPTION
Beforehand, the variable names for debug movement were incorrectly labelled for being for X and Y movement speed, when in reality, movement speed is global for all directions. The changes are as followed:
When one of the directional buttons is held, it counts the value previously listed as `v_debugxspeed` down until it reaches `$01`. Afterwards, it starts increasing the value next to it, `v_debugyspeed`, which is the true speed. 
I've changed `v_debugxspeed` to `v_debugspeedtimer` and `v_debugyspeed` to `v_debugspeed` to better explain its behavior. 
This change aligns with the official label in the Sonic 1 source code, which calls the new `v_debugspeedtimer` simply `edittimer`, and `v_debugyspeed` as `edittimer+1`.