### PR TITLE
Document and fix broken FM voice restoration in `StopSFX`

### DIFF
--- a/s1.sounddriver.asm
+++ b/s1.sounddriver.asm
@@ -1247,6 +1247,13 @@ StopSFX:
 .gotfmpointer:
 		bclr	#2,SMPS_Track.PlaybackControl(a5)	; Clear 'SFX is overriding' bit
 		bset	#1,SMPS_Track.PlaybackControl(a5)	; Set 'track at rest' bit
+	if FixBugs
+		moveq	#0, d0
+	else
+		; DANGER! `SetVoice` expects d0 to be a word, but it's only passed
+		; as a byte below. This may result in restoring invalid/broken FM
+		; voices during fade out sequence if upper byte of d0 was trashed.
+	endif
 		move.b	SMPS_Track.VoiceIndex(a5),d0		; Current voice
 		jsr	SetVoice(pc)
 		movea.l	a3,a5


### PR DESCRIPTION
I've recently discovered another SMPS bug and I didn't see it documented and mentioned anywhere, so let's fix that.

In SMPS, `StopSFX`  subroutine has a bug which may break restoration of FM voices. This sometimes results in broken FM voices after "fade out BGM" command if you're unlucky (it's the only place where this routine is called from).

Basically, this subroutine restores voices as follows:
```m68k
		move.b	SMPS_Track.VoiceIndex(a5),d0		; Current voice
		jsr	SetVoice(pc)
```
However, `SetVoice` expects `D0` to be a word:

```m68k
SetVoice:
		subq.w	#1,d0
		bmi.s	.havevoiceptr
		move.w	#25,d1
; loc_72C56:
.voicemultiply:
		adda.w	d1,a1
		dbf	d0,.voicemultiply
		; <...>
```

D0 is never properly cleared anywhere in `StopSFX` or in `PlaySoundID` > `Sound_E0toE4` > `FadeOutMusic` (its callers), so this code may break easily.

By pure luck, `StopSFX` is called exactly when "fade out BGM" command is processed, which means `CycleSoundQueue` is called before the subroutine chain listed above, and it happens to clear D0:
```m68k
; Sound_Play:
CycleSoundQueue:
		;< ...>
.havesound:
		andi.w	#$7F,d0				; Clear high byte and sign bit  <-------------------
		move.b	(a0,d0.w),d2			; Get sound type
		cmp.b	d3,d2				; Is it a lower priority sound?
		blo.s	.nextinput			; Branch if yes
		move.b	d2,d3				; Store new priority
		move.b	d1,SMPS_RAM.v_sound_id(a6)	; Queue sound for playing
		;< ...>
```
This masks the issue, but this setup is extremely fragile and may easily break with sound driver modifications (which it did in my case), so I would still treat it as a bug.
