### PR TITLE
Rename "PlaySound" routines to QueueSoundBuf1/2/3

### DIFF
--- a/_inc/DynamicLevelEvents.asm
+++ b/_inc/DynamicLevelEvents.asm
@@ -156,7 +156,7 @@ loc_6EB0:
 
 loc_6ED0:
 		move.w	#bgm_Boss,d0
-		bsr.w	PlaySound	; play boss music
+		bsr.w	QueueSound1	; play boss music
 		move.b	#1,(f_lockscreen).w ; lock screen
 		addq.b	#2,(v_dle_routine).w
 		moveq	#plcid_Boss,d0
@@ -200,7 +200,7 @@ DLE_LZ3:
 		beq.s	loc_6F28
 		move.b	#7,(a1)		; modify level layout
 		move.w	#sfx_Rumbling,d0
-		bsr.w	PlaySound_Special ; play rumbling sound
+		bsr.w	QueueSound2 ; play rumbling sound
 
 loc_6F28:
 		tst.b	(v_dle_routine).w
@@ -215,7 +215,7 @@ loc_6F28:
 
 loc_6F4A:
 		move.w	#bgm_Boss,d0
-		bsr.w	PlaySound	; play boss music
+		bsr.w	QueueSound1	; play boss music
 		move.b	#1,(f_lockscreen).w ; lock screen
 		addq.b	#2,(v_dle_routine).w
 		moveq	#plcid_Boss,d0
@@ -396,7 +396,7 @@ DLE_MZ3boss:
 
 loc_70D0:
 		move.w	#bgm_Boss,d0
-		bsr.w	PlaySound	; play boss music
+		bsr.w	QueueSound1	; play boss music
 		move.b	#1,(f_lockscreen).w ; lock screen
 		addq.b	#2,(v_dle_routine).w
 		moveq	#plcid_Boss,d0
@@ -461,7 +461,7 @@ DLE_SLZ3boss:
 
 loc_7144:
 		move.w	#bgm_Boss,d0
-		bsr.w	PlaySound	; play boss music
+		bsr.w	QueueSound1	; play boss music
 		move.b	#1,(f_lockscreen).w ; lock screen
 		addq.b	#2,(v_dle_routine).w
 		moveq	#plcid_Boss,d0
@@ -544,7 +544,7 @@ DLE_SYZ3boss:
 
 loc_71EC:
 		move.w	#bgm_Boss,d0
-		bsr.w	PlaySound	; play boss music
+		bsr.w	QueueSound1	; play boss music
 		move.b	#1,(f_lockscreen).w ; lock screen
 		moveq	#plcid_Boss,d0
 		bra.w	AddPLC		; load boss patterns

--- a/_inc/LZWaterFeatures.asm
+++ b/_inc/LZWaterFeatures.asm
@@ -172,7 +172,7 @@ DynWater_LZ3:
 		move.b	#$4B,(v_lvllayout+$80*2+6).w ; update level layout
 		move.b	#1,(v_wtr_routine).w ; use second routine next
 		move.w	#sfx_Rumbling,d0
-		bsr.w	PlaySound_Special ; play sound $B7 (rumbling)
+		bsr.w	QueueSound2 ; play sound $B7 (rumbling)
 
 .setwaterlz3:
 		move.w	d1,(v_waterpos3).w
@@ -316,7 +316,7 @@ LZWindTunnels:
 		andi.b	#$3F,d0		; does VInt counter fall on 0, $40, $80 or $C0?
 		bne.s	.skipsound	; if not, branch
 		move.w	#sfx_Waterfall,d0
-		jsr	(PlaySound_Special).l	; play rushing water sound (only every $40 frames)
+		jsr	(QueueSound2).l	; play rushing water sound (only every $40 frames)
 
 .skipsound:
 		tst.b	(f_wtunnelallow).w ; are wind tunnels disabled?
@@ -439,7 +439,7 @@ loc_3F9A:
 		andi.b	#$1F,d0
 		bne.s	locret_3FBE
 		move.w	#sfx_Waterfall,d0
-		jsr	(PlaySound_Special).l	; play water sound
+		jsr	(QueueSound2).l	; play water sound
 
 locret_3FBE:
 		rts	

--- a/_inc/Queue Sound Routines.asm
+++ b/_inc/Queue Sound Routines.asm
@@ -1,5 +1,5 @@
 ; ---------------------------------------------------------------------------
-; Subroutine to	play a music track
+; Subroutine to	queue a sound into buffer 1, often used for BGM
 
 ; input:
 ;	d0 = track to play
@@ -8,28 +8,29 @@
 ; ||||||||||||||| S U B	R O U T	I N E |||||||||||||||||||||||||||||||||||||||
 
 
-PlaySound:
+QueueSound1:
 		move.b	d0,(v_snddriver_ram.v_soundqueue0).w
 		rts	
-; End of function PlaySound
+; End of function QueueSound1
 
 ; ---------------------------------------------------------------------------
-; Subroutine to	play a sound effect
+; Subroutine to	queue a sound into buffer 2, often used for SFX
 ; ---------------------------------------------------------------------------
 
 ; ||||||||||||||| S U B	R O U T	I N E |||||||||||||||||||||||||||||||||||||||
 
 
-PlaySound_Special:
+QueueSound2:
 		move.b	d0,(v_snddriver_ram.v_soundqueue1).w
 		rts	
-; End of function PlaySound_Special
+; End of function QueueSound2
 
 ; ===========================================================================
 ; ---------------------------------------------------------------------------
-; Unused sound/music subroutine
+; Subroutine to	queue a sound into buffer 3, unused and broken.
+; Enabling "FixBugs" will make this usable.
 ; ---------------------------------------------------------------------------
 
-PlaySound_Unused:
+QueueSound3:
 		move.b	d0,(v_snddriver_ram.v_soundqueue2).w
 		rts	

--- a/_incObj/09 Sonic in Special Stage.asm
+++ b/_incObj/09 Sonic in Special Stage.asm
@@ -223,7 +223,7 @@ Obj09_Jump:
 		move.w	d0,obVelY(a0)
 		bset	#1,obStatus(a0)
 		move.w	#sfx_Jump,d0
-		jsr	(PlaySound_Special).l	; play jumping sound
+		jsr	(QueueSound2).l	; play jumping sound
 
 Obj09_NoJump:
 		rts	
@@ -476,7 +476,7 @@ Obj09_GetCont:
 		bne.s	Obj09_NoCont
 		addq.b	#1,(v_continues).w ; add 1 to number of continues
 		move.w	#sfx_Continue,d0
-		jsr	(PlaySound).l	; play extra continue sound
+		jsr	(QueueSound1).l	; play extra continue sound
 
 Obj09_NoCont:
 		moveq	#0,d4
@@ -495,7 +495,7 @@ Obj09_Get1Up:
 		addq.b	#1,(v_lives).w	; add 1 to number of lives
 		addq.b	#1,(f_lifecount).w ; update the lives counter
 		move.w	#bgm_ExtraLife,d0
-		jsr	(PlaySound).l	; play extra life music
+		jsr	(QueueSound1).l	; play extra life music
 		moveq	#0,d4
 		rts	
 ; ===========================================================================
@@ -522,7 +522,7 @@ Obj09_GetEmer:
 
 Obj09_NoEmer:
 		move.w	#bgm_Emerald,d0
-		jsr	(PlaySound_Special).l ;	play emerald music
+		jsr	(QueueSound2).l ;	play emerald music
 		moveq	#0,d4
 		rts	
 ; ===========================================================================
@@ -623,7 +623,7 @@ Obj09_ChkBumper:
 
 Obj09_BumpSnd:
 		move.w	#sfx_Bumper,d0
-		jmp	(PlaySound_Special).l	; play bumper sound
+		jmp	(QueueSound2).l	; play bumper sound
 ; ===========================================================================
 
 Obj09_GOAL:
@@ -631,7 +631,7 @@ Obj09_GOAL:
 		bne.s	Obj09_UPblock
 		addq.b	#2,obRoutine(a0) ; run routine "Obj09_ExitStage"
 		move.w	#sfx_SSGoal,d0
-		jsr	(PlaySound_Special).l	; play "GOAL" sound
+		jsr	(QueueSound2).l	; play "GOAL" sound
 		rts	
 ; ===========================================================================
 
@@ -650,7 +650,7 @@ Obj09_UPblock:
 
 Obj09_UPsnd:
 		move.w	#sfx_SSItem,d0
-		jmp	(PlaySound_Special).l	; play up/down sound
+		jmp	(QueueSound2).l	; play up/down sound
 ; ===========================================================================
 
 Obj09_DOWNblock:
@@ -668,7 +668,7 @@ Obj09_DOWNblock:
 
 Obj09_DOWNsnd:
 		move.w	#sfx_SSItem,d0
-		jmp	(PlaySound_Special).l	; play up/down sound
+		jmp	(QueueSound2).l	; play up/down sound
 ; ===========================================================================
 
 Obj09_Rblock:
@@ -687,7 +687,7 @@ Obj09_Rblock:
 Obj09_RevStage:
 		neg.w	(v_ssrotate).w	; reverse stage rotation
 		move.w	#sfx_SSItem,d0
-		jmp	(PlaySound_Special).l	; play sound
+		jmp	(QueueSound2).l	; play sound
 ; ===========================================================================
 
 Obj09_ChkGlass:
@@ -718,7 +718,7 @@ Obj09_GlassUpdate:
 
 Obj09_GlassSnd:
 		move.w	#sfx_SSGlass,d0
-		jmp	(PlaySound_Special).l	; play glass block sound
+		jmp	(QueueSound2).l	; play glass block sound
 ; ===========================================================================
 
 Obj09_NoGlass:

--- a/_incObj/0A Drowning Countdown.asm
+++ b/_incObj/0A Drowning Countdown.asm
@@ -208,7 +208,7 @@ Drown_Countdown:; Routine $A
 
 		bne.s	.skipmusic	; if air is less than 12, branch
 		move.w	#bgm_Drowning,d0
-		jsr	(PlaySound).l	; play countdown music
+		jsr	(QueueSound1).l	; play countdown music
 
 .skipmusic:
 		subq.b	#1,objoff_32(a0)
@@ -220,7 +220,7 @@ Drown_Countdown:; Routine $A
 
 .warnsound:
 		move.w	#sfx_Warning,d0
-		jsr	(PlaySound_Special).l	; play "ding-ding" warning sound
+		jsr	(QueueSound2).l	; play "ding-ding" warning sound
 
 .reduceair:
 		subq.w	#1,(v_air).w	; subtract 1 from air remaining
@@ -230,7 +230,7 @@ Drown_Countdown:; Routine $A
 		bsr.w	ResumeMusic
 		move.b	#$81,(f_playerctrl).w ; lock controls and disable object interaction
 		move.w	#sfx_Drown,d0
-		jsr	(PlaySound_Special).l	; play drowning sound
+		jsr	(QueueSound2).l	; play drowning sound
 		move.b	#$A,objoff_34(a0)
 		move.w	#1,objoff_36(a0)
 		move.w	#$78,objoff_2C(a0)

--- a/_incObj/0C Flapping Door.asm
+++ b/_incObj/0C Flapping Door.asm
@@ -34,7 +34,7 @@ Flap_OpenClose:	; Routine 2
 		tst.b	obRender(a0)
 		bpl.s	.nosound
 		move.w	#sfx_Door,d0
-		jsr	(PlaySound_Special).l	; play door sound
+		jsr	(QueueSound2).l	; play door sound
 
 .wait:
 .nosound:

--- a/_incObj/0D Signpost.asm
+++ b/_incObj/0D Signpost.asm
@@ -39,7 +39,7 @@ Sign_Touch:	; Routine 2
 		cmpi.w	#$20,d0		; is Sonic within $20 pixels of	the signpost?
 		bhs.s	.notouch	; if not, branch
 		move.w	#sfx_Signpost,d0
-		jsr	(PlaySound).l	; play signpost sound
+		jsr	(QueueSound1).l	; play signpost sound
 		clr.b	(f_timecount).w	; stop time counter
 		move.w	(v_limitright2).w,(v_limitleft2).w ; lock screen position
 		addq.b	#2,obRoutine(a0)
@@ -166,7 +166,7 @@ GotThroughAct:
 		mulu.w	#10,d0		; multiply by 10
 		move.w	d0,(v_ringbonus).w ; set ring bonus
 		move.w	#bgm_GotThrough,d0
-		jsr	(PlaySound_Special).l	; play "Sonic got through" music
+		jsr	(QueueSound2).l	; play "Sonic got through" music
 
 locret_ECEE:
 		rts	

--- a/_incObj/14 Lava Ball.asm
+++ b/_incObj/14 Lava Ball.asm
@@ -56,7 +56,7 @@ LBall_Main:	; Routine 0
 
 .sound:
 		move.w	#sfx_Fireball,d0
-		jsr	(PlaySound_Special).l	; play lava ball sound
+		jsr	(QueueSound2).l	; play lava ball sound
 
 LBall_Action:	; Routine 2
 		moveq	#0,d0

--- a/_incObj/24, 27 & 3F Explosions.asm
+++ b/_incObj/24, 27 & 3F Explosions.asm
@@ -23,7 +23,7 @@ MDis_Main:	; Routine 0
 		move.b	#9,obTimeFrame(a0)
 		move.b	#0,obFrame(a0)
 		move.w	#sfx_A5,d0
-		jsr	(PlaySound_Special).l		 ; play sound
+		jsr	(QueueSound2).l		 ; play sound
 
 MDis_Animate:	; Routine 2
 		subq.b	#1,obTimeFrame(a0) ; subtract 1 from frame duration
@@ -72,7 +72,7 @@ ExItem_Main:	; Routine 2
 		move.b	#7,obTimeFrame(a0) ; set frame duration to 7 frames
 		move.b	#0,obFrame(a0)
 		move.w	#sfx_BreakItem,d0
-		jsr	(PlaySound_Special).l	; play breaking enemy sound
+		jsr	(QueueSound2).l	; play breaking enemy sound
 
 ExItem_Animate:	; Routine 4 (2 for ExplosionBomb)
 		subq.b	#1,obTimeFrame(a0) ; subtract 1 from frame duration
@@ -110,4 +110,4 @@ ExBom_Main:	; Routine 0
 		move.b	#7,obTimeFrame(a0)
 		move.b	#0,obFrame(a0)
 		move.w	#sfx_Bomb,d0
-		jmp	(PlaySound_Special).l	; play exploding bomb sound
+		jmp	(QueueSound2).l	; play exploding bomb sound

--- a/_incObj/25 & 37 Rings.asm
+++ b/_incObj/25 & 37 Rings.asm
@@ -155,7 +155,7 @@ CollectRing:
 		move.w	#bgm_ExtraLife,d0 ; play extra life music
 
 .playsnd:
-		jmp	(PlaySound_Special).l
+		jmp	(QueueSound2).l
 ; End of function CollectRing
 
 ; ===========================================================================
@@ -237,7 +237,7 @@ RLoss_Count:	; Routine 0
 		move.b	#$80,(f_ringcount).w ; update ring counter
 		move.b	#0,(v_lifecount).w
 		move.w	#sfx_RingLoss,d0
-		jsr	(PlaySound_Special).l	; play ring loss sound
+		jsr	(QueueSound2).l	; play ring loss sound
 
 RLoss_Bounce:	; Routine 2
 		move.b	(v_ani3_frame).w,obFrame(a0)

--- a/_incObj/2E Monitor Content Power-Up.asm
+++ b/_incObj/2E Monitor Content Power-Up.asm
@@ -58,7 +58,7 @@ ExtraLife:
 		addq.b	#1,(v_lives).w	; add 1 to the number of lives you have
 		addq.b	#1,(f_lifecount).w ; update the lives counter
 		move.w	#bgm_ExtraLife,d0
-		jmp	(PlaySound).l	; play extra life music
+		jmp	(QueueSound1).l	; play extra life music
 ; ===========================================================================
 
 Pow_ChkShoes:
@@ -71,7 +71,7 @@ Pow_ChkShoes:
 		move.w	#$18,(v_sonspeedacc).w	; change Sonic's acceleration
 		move.w	#$80,(v_sonspeeddec).w	; change Sonic's deceleration
 		move.w	#bgm_Speedup,d0
-		jmp	(PlaySound).l		; Speed	up the music
+		jmp	(QueueSound1).l		; Speed	up the music
 ; ===========================================================================
 
 Pow_ChkShield:
@@ -81,7 +81,7 @@ Pow_ChkShield:
 		move.b	#1,(v_shield).w	; give Sonic a shield
 		move.b	#id_ShieldItem,(v_shieldobj).w ; load shield object ($38)
 		move.w	#sfx_Shield,d0
-		jmp	(PlaySound).l	; play shield sound
+		jmp	(QueueSound1).l	; play shield sound
 ; ===========================================================================
 
 Pow_ChkInvinc:
@@ -105,7 +105,7 @@ Pow_ChkInvinc:
 			bls.s	Pow_NoMusic
 		endif
 		move.w	#bgm_Invincible,d0
-		jmp	(PlaySound).l ; play invincibility music
+		jmp	(QueueSound1).l ; play invincibility music
 ; ===========================================================================
 
 Pow_NoMusic:
@@ -129,7 +129,7 @@ Pow_ChkRings:
 
 Pow_RingSound:
 		move.w	#sfx_Ring,d0
-		jmp	(PlaySound).l	; play ring sound
+		jmp	(QueueSound1).l	; play ring sound
 ; ===========================================================================
 
 Pow_ChkS:

--- a/_incObj/31 Chained Stompers.asm
+++ b/_incObj/31 Chained Stompers.asm
@@ -203,7 +203,7 @@ loc_B872:
 		tst.b	obRender(a0)
 		bpl.s	loc_B892
 		move.w	#sfx_ChainRise,d0
-		jsr	(PlaySound_Special).l	; play rising chain sound
+		jsr	(QueueSound2).l	; play rising chain sound
 
 loc_B892:
 		subi.w	#$80,objoff_32(a0)
@@ -229,7 +229,7 @@ loc_B8A8:
 		tst.b	obRender(a0)
 		bpl.s	CStom_Restart
 		move.w	#sfx_ChainStomp,d0
-		jsr	(PlaySound_Special).l	; play stomping sound
+		jsr	(QueueSound2).l	; play stomping sound
 
 CStom_Restart:
 		moveq	#0,d0
@@ -255,7 +255,7 @@ loc_B902:
 		tst.b	obRender(a0)
 		bpl.s	loc_B91C
 		move.w	#sfx_ChainRise,d0
-		jsr	(PlaySound_Special).l	; play rising chain sound
+		jsr	(QueueSound2).l	; play rising chain sound
 
 loc_B91C:
 		subi.w	#$80,objoff_32(a0)
@@ -282,7 +282,7 @@ loc_B938:
 		tst.b	obRender(a0)
 		bpl.s	loc_B97C
 		move.w	#sfx_ChainStomp,d0
-		jsr	(PlaySound_Special).l	; play stomping sound
+		jsr	(QueueSound2).l	; play stomping sound
 
 loc_B97C:
 		bra.w	CStom_Restart

--- a/_incObj/32 Button.asm
+++ b/_incObj/32 Button.asm
@@ -63,7 +63,7 @@ loc_BDC8:
 		tst.b	(a3)
 		bne.s	loc_BDD6
 		move.w	#sfx_Switch,d0
-		jsr	(PlaySound_Special).l	; play switch sound
+		jsr	(QueueSound2).l	; play switch sound
 
 loc_BDD6:
 		bset	d3,(a3)

--- a/_incObj/33 Pushable Blocks.asm
+++ b/_incObj/33 Pushable Blocks.asm
@@ -338,7 +338,7 @@ loc_C294:
 		move.w	#0,obVelX(a1)
 		move.w	d0,-(sp)
 		move.w	#sfx_Push,d0
-		jsr	(PlaySound_Special).l	 ; play pushing sound
+		jsr	(QueueSound2).l	 ; play pushing sound
 		move.w	(sp)+,d0
 		tst.b	obSubtype(a0)
 		bmi.s	locret_C2E4

--- a/_incObj/35 Burning Grass.asm
+++ b/_incObj/35 Burning Grass.asm
@@ -26,7 +26,7 @@ GFire_Main:	; Routine 0
 		move.b	#$8B,obColType(a0)
 		move.b	#8,obActWid(a0)
 		move.w	#sfx_Burning,d0
-		jsr	(PlaySound_Special).l	 ; play burning sound
+		jsr	(QueueSound2).l	 ; play burning sound
 		tst.b	obSubtype(a0)
 		beq.s	loc_B238
 		addq.b	#2,obRoutine(a0)

--- a/_incObj/36 Spikes.asm
+++ b/_incObj/36 Spikes.asm
@@ -153,7 +153,7 @@ Spik_Wait:
 		tst.b	obRender(a0)
 		bpl.s	locret_CFE6
 		move.w	#sfx_SpikesMove,d0
-		jsr	(PlaySound_Special).l	; play "spikes moving" sound
+		jsr	(QueueSound2).l	; play "spikes moving" sound
 		bra.s	locret_CFE6
 ; ===========================================================================
 

--- a/_incObj/3A Got Through Card.asm
+++ b/_incObj/3A Got Through Card.asm
@@ -117,7 +117,7 @@ Got_ChkBonus:
 		tst.w	d0		; is there any bonus?
 		bne.s	Got_AddBonus	; if yes, branch
 		move.w	#sfx_Cash,d0
-		jsr	(PlaySound_Special).l	; play "ker-ching" sound
+		jsr	(QueueSound2).l	; play "ker-ching" sound
 		addq.b	#2,obRoutine(a0)
 		cmpi.w	#(id_SBZ<<8)+1,(v_zone).w
 		bne.s	Got_SetDelay
@@ -136,7 +136,7 @@ Got_AddBonus:
 		andi.b	#3,d0
 		bne.s	locret_C692
 		move.w	#sfx_Switch,d0
-		jmp	(PlaySound_Special).l	; play "blip" sound
+		jmp	(QueueSound2).l	; play "blip" sound
 ; ===========================================================================
 
 Got_NextLevel:	; Routine $A
@@ -239,7 +239,7 @@ Got_SBZ2:
 		addq.b	#2,obRoutine(a0)
 		clr.b	(f_lockctrl).w	; unlock controls
 		move.w	#bgm_FZ,d0
-		jmp	(PlaySound).l	; play FZ music
+		jmp	(QueueSound1).l	; play FZ music
 ; ===========================================================================
 
 loc_C766:	; Routine $10

--- a/_incObj/3D Boss - Green Hill (part 1).asm
+++ b/_incObj/3D Boss - Green Hill (part 1).asm
@@ -97,7 +97,7 @@ loc_177E6:
 		bne.s	BGHZ_ShipFlash
 		move.b	#$20,objoff_3E(a0)	; set number of	times for ship to flash
 		move.w	#sfx_HitBoss,d0
-		jsr	(PlaySound_Special).l	; play boss damage sound
+		jsr	(QueueSound2).l	; play boss damage sound
 
 BGHZ_ShipFlash:
 		lea	(v_palette+$22).w,a1 ; load 2nd palette, 2nd entry

--- a/_incObj/3D Boss - Green Hill (part 2).asm
+++ b/_incObj/3D Boss - Green Hill (part 2).asm
@@ -110,7 +110,7 @@ loc_179DA:
 loc_179E0:
 		clr.w	obVelY(a0)
 		move.w	#bgm_GHZ,d0
-		jsr	(PlaySound).l		; play GHZ music
+		jsr	(QueueSound1).l		; play GHZ music
 
 loc_179EE:
 		bsr.w	BossMove

--- a/_incObj/41 Springs.asm
+++ b/_incObj/41 Springs.asm
@@ -85,7 +85,7 @@ Spring_BounceUp:
 		bclr	#3,obStatus(a0)
 		clr.b	obSolid(a0)
 		move.w	#sfx_Spring,d0
-		jsr	(PlaySound_Special).l	; play spring sound
+		jsr	(QueueSound2).l	; play spring sound
 
 Spring_AniUp:	; Routine 4
 		lea	(Ani_Spring).l,a1
@@ -135,7 +135,7 @@ loc_DC56:
 		bclr	#5,obStatus(a0)
 		bclr	#5,obStatus(a1)
 		move.w	#sfx_Spring,d0
-		jsr	(PlaySound_Special).l	; play spring sound
+		jsr	(QueueSound2).l	; play spring sound
 
 Spring_AniLR:	; Routine $A
 		lea	(Ani_Spring).l,a1
@@ -179,7 +179,7 @@ Spring_BounceDwn:
 		bclr	#3,obStatus(a0)
 		clr.b	obSolid(a0)
 		move.w	#sfx_Spring,d0
-		jsr	(PlaySound_Special).l	; play spring sound
+		jsr	(QueueSound2).l	; play spring sound
 
 Spring_AniDwn:	; Routine $10
 		lea	(Ani_Spring).l,a1

--- a/_incObj/47 Bumper.asm
+++ b/_incObj/47 Bumper.asm
@@ -44,7 +44,7 @@ Bump_Hit:	; Routine 2
 		clr.b	objoff_3C(a1)
 		move.b	#1,obAnim(a0)	; use "hit" animation
 		move.w	#sfx_Bumper,d0
-		jsr	(PlaySound_Special).l	; play bumper sound
+		jsr	(QueueSound2).l	; play bumper sound
 		lea	(v_objstate).w,a2
 		moveq	#0,d0
 		move.b	obRespawnNo(a0),d0

--- a/_incObj/49 Waterfall Sound.asm
+++ b/_incObj/49 Waterfall Sound.asm
@@ -21,7 +21,7 @@ WSnd_PlaySnd:	; Routine 2
 		andi.b	#$3F,d0
 		bne.s	WSnd_ChkDel
 		move.w	#sfx_Waterfall,d0
-		jsr	(PlaySound_Special).l	; play waterfall sound
+		jsr	(QueueSound2).l	; play waterfall sound
 
 WSnd_ChkDel:
 		out_of_range.w	DeleteObject

--- a/_incObj/4A Special Stage Entry (Unused).asm
+++ b/_incObj/4A Special Stage Entry (Unused).asm
@@ -41,7 +41,7 @@ Van_RmvSonic:	; Routine 2
 		beq.s	.display
 		move.b	#0,(v_player).w	; remove Sonic
 		move.w	#sfx_SSGoal,d0
-		jsr	(PlaySound_Special).l	; play Special Stage "GOAL" sound
+		jsr	(QueueSound2).l	; play Special Stage "GOAL" sound
 
 .display:
 		jmp	(DisplaySprite).l

--- a/_incObj/4B Giant Ring.asm
+++ b/_incObj/4B Giant Ring.asm
@@ -56,7 +56,7 @@ GRing_Collect:	; Routine 4
 
 GRing_PlaySnd:
 		move.w	#sfx_GiantRing,d0
-		jsr	(PlaySound_Special).l	; play giant ring sound
+		jsr	(QueueSound2).l	; play giant ring sound
 		bra.s	GRing_Animate
 ; ===========================================================================
 

--- a/_incObj/4C & 4D Lava Geyser Maker.asm
+++ b/_incObj/4C & 4D Lava Geyser Maker.asm
@@ -211,7 +211,7 @@ Geyser_Main:	; Routine 0
 
 .sound:
 		move.w	#sfx_Burning,d0
-		jsr	(PlaySound_Special).l	; play flame sound
+		jsr	(QueueSound2).l	; play flame sound
 
 Geyser_Action:	; Routine 2
 		moveq	#0,d0

--- a/_incObj/55 Basaran.asm
+++ b/_incObj/55 Basaran.asm
@@ -99,7 +99,7 @@ Bas_Action:	; Routine 2
 		andi.b	#$F,d0
 		bne.s	.nosound
 		move.w	#sfx_Basaran,d0
-		jsr	(PlaySound_Special).l	; play flapping sound every 16th frame
+		jsr	(QueueSound2).l	; play flapping sound every 16th frame
 
 .nosound:
 		bsr.w	SpeedToPos

--- a/_incObj/5E Seesaw.asm
+++ b/_incObj/5E Seesaw.asm
@@ -256,7 +256,7 @@ See_Spring:
 		move.b	#id_Spring,obAnim(a2) ; change Sonic's animation to "spring" ($10)
 		move.b	#2,obRoutine(a2)
 		move.w	#sfx_Spring,d0
-		jsr	(PlaySound_Special).l	; play spring sound
+		jsr	(QueueSound2).l	; play spring sound
 
 loc_1192C:
 		clr.w	obVelX(a0)

--- a/_incObj/62 Gargoyle.asm
+++ b/_incObj/62 Gargoyle.asm
@@ -69,7 +69,7 @@ Gar_FireBall:	; Routine 4
 
 .noflip:
 		move.w	#sfx_Fireball,d0
-		jsr	(PlaySound_Special).l	; play lava ball sound
+		jsr	(QueueSound2).l	; play lava ball sound
 
 Gar_AniFire:	; Routine 6
 		move.b	(v_framebyte).w,d0

--- a/_incObj/64 Bubbles.asm
+++ b/_incObj/64 Bubbles.asm
@@ -81,7 +81,7 @@ Bub_ChkWater:	; Routine 4
 
 		bsr.w	ResumeMusic	; cancel countdown music
 		move.w	#sfx_Bubble,d0
-		jsr	(PlaySound_Special).l	; play collecting bubble sound
+		jsr	(QueueSound2).l	; play collecting bubble sound
 		lea	(v_player).w,a1
 		clr.w	obVelX(a1)
 		clr.w	obVelY(a1)

--- a/_incObj/69 SBZ Spinning Platforms.asm
+++ b/_incObj/69 SBZ Spinning Platforms.asm
@@ -59,7 +59,7 @@ Spin_Trapdoor:	; Routine 2
 		tst.b	obRender(a0)
 		bpl.s	.animate
 		move.w	#sfx_Door,d0
-		jsr	(PlaySound_Special).l	; play door sound
+		jsr	(QueueSound2).l	; play door sound
 
 .animate:
 		lea	(Ani_Spin).l,a1

--- a/_incObj/6A Saws and Pizza Cutters.asm
+++ b/_incObj/6A Saws and Pizza Cutters.asm
@@ -76,7 +76,7 @@ Saw_Action:	; Routine 2
 		andi.w	#$F,d0
 		bne.s	.nosound01
 		move.w	#sfx_Saw,d0
-		jsr	(PlaySound_Special).l		; play saw sound
+		jsr	(QueueSound2).l		; play saw sound
 
 .nosound01:
 		rts	
@@ -107,7 +107,7 @@ Saw_Action:	; Routine 2
 		cmpi.b	#$18,d0
 		bne.s	.nosound02
 		move.w	#sfx_Saw,d0
-		jsr	(PlaySound_Special).l		; play saw sound
+		jsr	(QueueSound2).l		; play saw sound
 
 .nosound02:
 		rts	
@@ -134,7 +134,7 @@ Saw_Action:	; Routine 2
 		move.b	#$A2,obColType(a0)
 		move.b	#2,obFrame(a0)
 		move.w	#sfx_Saw,d0
-		jsr	(PlaySound_Special).l		; play saw sound
+		jsr	(QueueSound2).l		; play saw sound
 
 .nosaw03x:
 		addq.l	#4,sp
@@ -174,7 +174,7 @@ Saw_Action:	; Routine 2
 		move.b	#$A2,obColType(a0)
 		move.b	#2,obFrame(a0)
 		move.w	#sfx_Saw,d0
-		jsr	(PlaySound_Special).l		; play saw sound
+		jsr	(QueueSound2).l		; play saw sound
 
 .nosaw04x:
 		addq.l	#4,sp

--- a/_incObj/6D Flamethrower.asm
+++ b/_incObj/6D Flamethrower.asm
@@ -43,7 +43,7 @@ Flame_Action:	; Routine 2
 		beq.s	loc_E57A
 		move.w	objoff_32(a0),objoff_30(a0)	; begin	flaming	time
 		move.w	#sfx_Flamethrower,d0
-		jsr	(PlaySound_Special).l ; play flame sound
+		jsr	(QueueSound2).l ; play flame sound
 
 loc_E57A:
 		lea	(Ani_Flame).l,a1

--- a/_incObj/6E Electrocuter.asm
+++ b/_incObj/6E Electrocuter.asm
@@ -35,7 +35,7 @@ Elec_Shock:	; Routine 2
 		tst.b	obRender(a0)
 		bpl.s	.animate
 		move.w	#sfx_Electric,d0
-		jsr	(PlaySound_Special).l	; play electricity sound
+		jsr	(QueueSound2).l	; play electricity sound
 
 .animate:
 		lea	(Ani_Elec).l,a1

--- a/_incObj/72 Teleporter.asm
+++ b/_incObj/72 Teleporter.asm
@@ -68,7 +68,7 @@ loc_1670E:
 		move.w	obY(a0),obY(a1)
 		clr.b	objoff_32(a0)
 		move.w	#sfx_Roll,d0
-		jsr	(PlaySound_Special).l	; play Sonic rolling sound
+		jsr	(QueueSound2).l	; play Sonic rolling sound
 
 locret_1675C:
 		rts	
@@ -88,7 +88,7 @@ loc_1675E:	; Routine 4
 		bsr.w	sub_1681C
 		addq.b	#2,obRoutine(a0)
 		move.w	#sfx_Teleport,d0
-		jsr	(PlaySound_Special).l	; play teleport sound
+		jsr	(QueueSound2).l	; play teleport sound
 
 locret_16796:
 		rts	

--- a/_incObj/73 Boss - Marble.asm
+++ b/_incObj/73 Boss - Marble.asm
@@ -105,7 +105,7 @@ loc_1833E:
 		bne.s	loc_18374
 		move.b	#$28,objoff_3E(a0)
 		move.w	#sfx_HitBoss,d0
-		jsr	(PlaySound_Special).l	; play boss damage sound
+		jsr	(QueueSound2).l	; play boss damage sound
 
 loc_18374:
 		lea	(v_palette+$22).w,a1
@@ -307,7 +307,7 @@ loc_18566:
 loc_1856C:
 		clr.w	obVelY(a0)
 		move.w	#bgm_MZ,d0
-		jsr	(PlaySound).l		; play MZ music
+		jsr	(QueueSound1).l		; play MZ music
 
 loc_1857A:
 		bsr.w	BossMove

--- a/_incObj/74 MZ Boss Fire.asm
+++ b/_incObj/74 MZ Boss Fire.asm
@@ -40,7 +40,7 @@ BossFire_Main:	; Routine 0
 loc_1870A:
 		move.b	#$1E,objoff_29(a0)
 		move.w	#sfx_Fireball,d0
-		jsr	(PlaySound_Special).l	; play lava sound
+		jsr	(QueueSound2).l	; play lava sound
 
 BossFire_Action:	; Routine 2
 		moveq	#0,d0

--- a/_incObj/75 Boss - Spring Yard.asm
+++ b/_incObj/75 Boss - Spring Yard.asm
@@ -110,7 +110,7 @@ loc_19202:
 		bne.s	loc_1923A
 		move.b	#$20,objoff_3E(a0)
 		move.w	#sfx_HitBoss,d0
-		jsr	(PlaySound_Special).l	; play boss damage sound
+		jsr	(QueueSound2).l	; play boss damage sound
 
 loc_1923A:
 		lea	(v_palette+$22).w,a1
@@ -426,7 +426,7 @@ loc_194DA:
 loc_194E0:
 		clr.w	obVelY(a0)
 		move.w	#bgm_SYZ,d0
-		jsr	(PlaySound).l		; play SYZ music
+		jsr	(QueueSound1).l		; play SYZ music
 
 loc_194EE:
 		bra.w	loc_191F2

--- a/_incObj/76 SYZ Boss Blocks.asm
+++ b/_incObj/76 SYZ Boss Blocks.asm
@@ -139,7 +139,7 @@ loc_197AA:
 
 loc_197D4:
 		move.w	#sfx_WallSmash,d0
-		jmp	(PlaySound_Special).l	; play smashing sound
+		jmp	(QueueSound2).l	; play smashing sound
 ; End of function BossBlock_Break
 
 ; ===========================================================================

--- a/_incObj/77 Boss - Labyrinth.asm
+++ b/_incObj/77 Boss - Labyrinth.asm
@@ -99,7 +99,7 @@ loc_17F48:
 		bne.s	loc_17F70
 		move.b	#$20,objoff_3E(a0)
 		move.w	#sfx_HitBoss,d0
-		jsr	(PlaySound_Special).l
+		jsr	(QueueSound2).l
 
 loc_17F70:
 		lea	(v_palette+$22).w,a1
@@ -273,7 +273,7 @@ loc_180F6:
 
 loc_18112:
 		move.w	#bgm_LZ,d0
-		jsr	(PlaySound).l		; play LZ music
+		jsr	(QueueSound1).l		; play LZ music
 		if Revision<>0
 			clr.b	(f_lockscreen).w
 		endif

--- a/_incObj/79 Lamppost.asm
+++ b/_incObj/79 Lamppost.asm
@@ -79,7 +79,7 @@ Lamp_Blue:	; Routine 2
 		bhs.s	.donothing
 
 		move.w	#sfx_Lamppost,d0
-		jsr	(PlaySound_Special).l	; play lamppost sound
+		jsr	(QueueSound2).l	; play lamppost sound
 		addq.b	#2,obRoutine(a0)
 		jsr	(FindFreeObj).l
 		bne.s	.fail

--- a/_incObj/7A Boss - Star Light.asm
+++ b/_incObj/7A Boss - Star Light.asm
@@ -135,7 +135,7 @@ loc_189FE:
 		bne.s	loc_18A28
 		move.b	#$20,objoff_3E(a0)
 		move.w	#sfx_HitBoss,d0
-		jsr	(PlaySound_Special).l	; play boss damage sound
+		jsr	(QueueSound2).l	; play boss damage sound
 
 loc_18A28:
 		lea	(v_palette+$22).w,a1
@@ -317,7 +317,7 @@ loc_18BAE:
 loc_18BB4:
 		clr.w	obVelY(a0)
 		move.w	#bgm_SLZ,d0
-		jsr	(PlaySound).l		; play SLZ music
+		jsr	(QueueSound1).l		; play SLZ music
 
 loc_18BC2:
 		bra.w	loc_189EE

--- a/_incObj/7B SLZ Boss Spikeball.asm
+++ b/_incObj/7B SLZ Boss Spikeball.asm
@@ -302,7 +302,7 @@ loc_18FDC:
 		movea.l	(sp)+,a0
 		move.b	#2,obRoutine(a2)
 		move.w	#sfx_Spring,d0
-		jsr	(PlaySound_Special).l	; play "spring" sound
+		jsr	(QueueSound2).l	; play "spring" sound
 
 loc_19008:
 		clr.w	obVelX(a0)

--- a/_incObj/7D Hidden Bonuses.asm
+++ b/_incObj/7D Hidden Bonuses.asm
@@ -42,7 +42,7 @@ Bonus_Main:	; Routine 0
 		move.b	obSubtype(a0),obFrame(a0)
 		move.w	#119,bonus_timelen(a0) ; set display time to 2 seconds
 		move.w	#sfx_Bonus,d0
-		jsr	(PlaySound_Special).l	; play bonus sound
+		jsr	(QueueSound2).l	; play bonus sound
 		moveq	#0,d0
 		move.b	obSubtype(a0),d0
 		add.w	d0,d0

--- a/_incObj/7E Special Stage Results.asm
+++ b/_incObj/7E Special Stage Results.asm
@@ -114,12 +114,12 @@ SSR_RingBonus:	; Routine 6
 		andi.b	#3,d0
 		bne.s	locret_C8EA
 		move.w	#sfx_Switch,d0
-		jmp	(PlaySound_Special).l	; play "blip" sound
+		jmp	(QueueSound2).l	; play "blip" sound
 ; ===========================================================================
 
 loc_C8C4:
 		move.w	#sfx_Cash,d0
-		jsr	(PlaySound_Special).l	; play "ker-ching" sound
+		jsr	(QueueSound2).l	; play "ker-ching" sound
 		addq.b	#2,obRoutine(a0)
 		move.w	#180,obTimeFrame(a0) ; set time delay to 3 seconds
 		cmpi.w	#50,(v_rings).w	; do you have at least 50 rings?
@@ -140,7 +140,7 @@ SSR_Continue:	; Routine $E
 		move.b	#4,(v_ssrescontinue+obFrame).w
 		move.b	#$14,(v_ssrescontinue+obRoutine).w
 		move.w	#sfx_Continue,d0
-		jsr	(PlaySound_Special).l	; play continues jingle
+		jsr	(QueueSound2).l	; play continues jingle
 		addq.b	#2,obRoutine(a0)
 		move.w	#360,obTimeFrame(a0) ; set time delay to 6 seconds
 		bra.w	DisplaySprite

--- a/_incObj/81 Continue Screen Sonic.asm
+++ b/_incObj/81 Continue Screen Sonic.asm
@@ -57,7 +57,7 @@ CSon_GetUp:
 		clr.w	obInertia(a0)
 		subq.w	#8,obY(a0)
 		move.b	#bgm_Fade,d0
-		bsr.w	PlaySound_Special ; fade out music
+		bsr.w	QueueSound2 ; fade out music
 
 CSon_Run:	; Routine 6
 		cmpi.w	#$800,obInertia(a0) ; check Sonic's inertia

--- a/_incObj/83 SBZ Eggman's Crumbling Floor.asm
+++ b/_incObj/83 SBZ Eggman's Crumbling Floor.asm
@@ -151,7 +151,7 @@ loc_19CC4:
 
 FFloor_BreakSnd:
 		move.w	#sfx_WallSmash,d0
-		jsr	(PlaySound_Special).l	; play smashing sound
+		jsr	(QueueSound2).l	; play smashing sound
 		jmp	(DisplaySprite).l
 ; ===========================================================================
 FFloor_FragSpeed:dc.w $80, 0

--- a/_incObj/85 Boss - Final.asm
+++ b/_incObj/85 Boss - Final.asm
@@ -156,7 +156,7 @@ loc_19EC6:
 		move.w	#1,objoff_32(a0)
 		clr.b	objoff_35(a0)
 		move.w	#sfx_Rumbling,d0
-		jsr	(PlaySound_Special).l	; play rumbling sound
+		jsr	(QueueSound2).l	; play rumbling sound
 
 loc_19F10:
 		tst.w	objoff_32(a0)
@@ -198,7 +198,7 @@ loc_19F6A:
 		subq.b	#1,obColProp(a0)
 		move.b	#$64,objoff_35(a0)
 		move.w	#sfx_HitBoss,d0
-		jsr	(PlaySound_Special).l	; play boss damage sound
+		jsr	(QueueSound2).l	; play boss damage sound
 
 loc_19F88:
 		subq.b	#1,objoff_35(a0)
@@ -267,7 +267,7 @@ locret_1A01E:
 
 loc_1A020:
 		move.w	#sfx_Electric,d0
-		jmp	(PlaySound_Special).l	; play electricity sound
+		jmp	(QueueSound2).l	; play electricity sound
 ; ===========================================================================
 
 loc_1A02A:
@@ -419,7 +419,7 @@ loc_1A1D4:
 		bne.s	loc_1A216
 		move.w	#$1E,objoff_30(a0)
 		move.w	#sfx_HitBoss,d0
-		jsr	(PlaySound_Special).l	; play boss damage sound
+		jsr	(QueueSound2).l	; play boss damage sound
 
 loc_1A1FC:
 		subq.w	#1,objoff_30(a0)

--- a/_incObj/Sonic (part 2).asm
+++ b/_incObj/Sonic (part 2).asm
@@ -89,7 +89,7 @@ GameOver:
 
 loc_138C2:
 		move.w	#bgm_GameOver,d0
-		jsr	(PlaySound).l	; play game over music
+		jsr	(QueueSound1).l	; play game over music
 		moveq	#plcid_GameOver,d0
 		jmp	(AddPLC).l	; load game over patterns
 ; ===========================================================================

--- a/_incObj/Sonic Display.asm
+++ b/_incObj/Sonic Display.asm
@@ -32,7 +32,7 @@ Sonic_Display:
 .music:
 		lea	(MusicList2).l,a1
 		move.b	(a1,d0.w),d0
-		jsr	(PlaySound).l	; play normal music
+		jsr	(QueueSound1).l	; play normal music
 
 .removeinvincible:
 		move.b	#0,(v_invinc).w ; cancel invincibility
@@ -49,7 +49,7 @@ Sonic_Display:
 		move.w	#$80,(v_sonspeeddec).w ; restore Sonic's deceleration
 		move.b	#0,(v_shoes).w	; cancel speed shoes
 		move.w	#bgm_Slowdown,d0
-		jmp	(PlaySound).l	; run music at normal speed
+		jmp	(QueueSound1).l	; run music at normal speed
 
 .exit:
 		rts	

--- a/_incObj/Sonic Jump.asm
+++ b/_incObj/Sonic Jump.asm
@@ -37,7 +37,7 @@ loc_1341C:
 		move.b	#1,objoff_3C(a0)
 		clr.b	stick_to_convex(a0)
 		move.w	#sfx_Jump,d0
-		jsr	(PlaySound_Special).l	; play jumping sound
+		jsr	(QueueSound2).l	; play jumping sound
 		move.b	#$13,obHeight(a0)
 		move.b	#9,obWidth(a0)
 		btst	#2,obStatus(a0)

--- a/_incObj/Sonic Move.asm
+++ b/_incObj/Sonic Move.asm
@@ -237,7 +237,7 @@ loc_130BA:
 		move.b	#id_Stop,obAnim(a0) ; use "stopping" animation
 		bclr	#0,obStatus(a0)
 		move.w	#sfx_Skid,d0
-		jsr	(PlaySound_Special).l	; play stopping sound
+		jsr	(QueueSound2).l	; play stopping sound
 
 locret_130E8:
 		rts	
@@ -283,7 +283,7 @@ loc_13120:
 		move.b	#id_Stop,obAnim(a0) ; use "stopping" animation
 		bset	#0,obStatus(a0)
 		move.w	#sfx_Skid,d0
-		jsr	(PlaySound_Special).l	; play stopping sound
+		jsr	(QueueSound2).l	; play stopping sound
 
 locret_1314E:
 		rts	

--- a/_incObj/Sonic Roll.asm
+++ b/_incObj/Sonic Roll.asm
@@ -38,7 +38,7 @@ Sonic_ChkRoll:
 		move.b	#id_Roll,obAnim(a0) ; use "rolling" animation
 		addq.w	#5,obY(a0)
 		move.w	#sfx_Roll,d0
-		jsr	(PlaySound_Special).l	; play rolling sound
+		jsr	(QueueSound2).l	; play rolling sound
 		tst.w	obInertia(a0)
 		bne.s	.ismoving
 		move.w	#$200,obInertia(a0) ; set inertia if 0

--- a/_incObj/Sonic Water.asm
+++ b/_incObj/Sonic Water.asm
@@ -31,7 +31,7 @@ Sonic_Water:
 		beq.s	.exit		; branch if Sonic stops moving
 		move.b	#id_Splash,(v_splash).w ; load splash object
 		move.w	#sfx_Splash,d0
-		jmp	(PlaySound_Special).l	 ; play splash sound
+		jmp	(QueueSound2).l	 ; play splash sound
 ; ===========================================================================
 
 .abovewater:
@@ -50,5 +50,5 @@ Sonic_Water:
 
 .belowmaxspeed:
 		move.w	#sfx_Splash,d0
-		jmp	(PlaySound_Special).l	 ; play splash sound
+		jmp	(QueueSound2).l	 ; play splash sound
 ; End of function Sonic_Water

--- a/_incObj/sub ReactToItem.asm
+++ b/_incObj/sub ReactToItem.asm
@@ -310,7 +310,7 @@ HurtSonic:
 	endif
 
 .sound:
-		jsr	(PlaySound_Special).l
+		jsr	(QueueSound2).l
 		moveq	#-1,d0
 		rts	
 ; ===========================================================================
@@ -355,7 +355,7 @@ KillSonic:
 	endif
 
 .sound:
-		jsr	(PlaySound_Special).l
+		jsr	(QueueSound2).l
 
 .dontdie:
 		moveq	#-1,d0

--- a/_incObj/sub SmashObject.asm
+++ b/_incObj/sub SmashObject.asm
@@ -50,6 +50,6 @@ SmashObject:
 
 .playsnd:
 		move.w	#sfx_WallSmash,d0
-		jmp	(PlaySound_Special).l ; play smashing sound
+		jmp	(QueueSound2).l ; play smashing sound
 
 ; End of function SmashObject

--- a/sonic.asm
+++ b/sonic.asm
@@ -1077,7 +1077,7 @@ DACDriverLoad:
 		rts	
 ; End of function DACDriverLoad
 
-		include	"_incObj/sub PlaySound.asm"
+		include	"_inc/Queue Sound Routines.asm"
 		include	"_inc/PauseGame.asm"
 
 ; ---------------------------------------------------------------------------
@@ -2023,7 +2023,7 @@ WaitForVBla:
 
 GM_Sega:
 		move.b	#bgm_Stop,d0
-		bsr.w	PlaySound_Special ; stop music
+		bsr.w	QueueSound2 ; stop music
 		bsr.w	ClearPLC
 		bsr.w	PaletteFadeOut
 		lea	(vdp_control_port).l,a6
@@ -2073,7 +2073,7 @@ Sega_WaitPal:
 		bne.s	Sega_WaitPal
 
 		move.b	#sfx_Sega,d0
-		bsr.w	PlaySound_Special	; play "SEGA" sound
+		bsr.w	QueueSound2	; play "SEGA" sound
 		move.b	#$14,(v_vbla_routine).w
 		bsr.w	WaitForVBla
 		move.w	#30,(v_demolength).w
@@ -2097,7 +2097,7 @@ Sega_GotoTitle:
 
 GM_Title:
 		move.b	#bgm_Stop,d0
-		bsr.w	PlaySound_Special ; stop music
+		bsr.w	QueueSound2 ; stop music
 		bsr.w	ClearPLC
 		bsr.w	PaletteFadeOut
 		disable_ints
@@ -2193,7 +2193,7 @@ Tit_LoadText:
 		moveq	#palid_Title,d0	; load title screen palette
 		bsr.w	PalLoad_Fade
 		move.b	#bgm_Title,d0
-		bsr.w	PlaySound_Special	; play title screen music
+		bsr.w	QueueSound2	; play title screen music
 		move.b	#0,(f_debugmode).w ; disable debug mode
 		move.w	#376,(v_demolength).w ; run title screen for 376 frames
 		
@@ -2283,7 +2283,7 @@ Tit_EnterCheat:
 Tit_PlayRing:
 		move.b	#1,(a0,d1.w)	; activate cheat
 		move.b	#sfx_Ring,d0
-		bsr.w	PlaySound_Special	; play ring sound when code is entered
+		bsr.w	QueueSound2	; play ring sound when code is entered
 		bra.s	Tit_CountC
 ; ===========================================================================
 
@@ -2363,7 +2363,7 @@ LevSel_NoCheat:
 		blo.s	LevelSelect	; if yes, branch
 
 LevSel_PlaySnd:
-		bsr.w	PlaySound_Special
+		bsr.w	QueueSound2
 		bra.s	LevelSelect
 ; ===========================================================================
 
@@ -2376,7 +2376,7 @@ LevSel_Ending:
 LevSel_Credits:
 		move.b	#id_Credits,(v_gamemode).w ; set screen mode to $1C (Credits)
 		move.b	#bgm_Credits,d0
-		bsr.w	PlaySound_Special ; play credits music
+		bsr.w	QueueSound2 ; play credits music
 		move.w	#0,(v_creditsnum).w
 		rts	
 ; ===========================================================================
@@ -2420,7 +2420,7 @@ PlayLevel:
 			move.l	#5000,(v_scorelife).w ; extra life is awarded at 50000 points
 		endif
 		move.b	#bgm_Fade,d0
-		bsr.w	PlaySound_Special ; fade out music
+		bsr.w	QueueSound2 ; fade out music
 		rts	
 ; ===========================================================================
 ; ---------------------------------------------------------------------------
@@ -2514,7 +2514,7 @@ loc_33E4:
 		tst.w	(v_demolength).w
 		bne.w	loc_33B6
 		move.b	#bgm_Fade,d0
-		bsr.w	PlaySound_Special ; fade out music
+		bsr.w	QueueSound2 ; fade out music
 		move.w	(v_demonum).w,d0 ; load	demo number
 		andi.w	#7,d0
 		add.w	d0,d0
@@ -2750,7 +2750,7 @@ GM_Level:
 		tst.w	(f_demo).w
 		bmi.s	Level_NoMusicFade
 		move.b	#bgm_Fade,d0
-		bsr.w	PlaySound_Special ; fade out music
+		bsr.w	QueueSound2 ; fade out music
 
 Level_NoMusicFade:
 		bsr.w	ClearPLC
@@ -2846,7 +2846,7 @@ Level_BgmNotLZ4:
 Level_PlayBgm:
 		lea	(MusicList).l,a1 ; load	music playlist
 		move.b	(a1,d0.w),d0
-		bsr.w	PlaySound	; play music
+		bsr.w	QueueSound1	; play music
 		move.b	#id_TitleCard,(v_titlecard).w ; load title card object
 
 Level_TtlCardLoop:
@@ -3199,7 +3199,7 @@ Demo_SS:	binclude	"demodata/Intro - Special Stage.bin"
 
 GM_Special:
 		move.w	#sfx_EnterSS,d0
-		bsr.w	PlaySound_Special ; play special stage entry sound
+		bsr.w	QueueSound2 ; play special stage entry sound
 		bsr.w	PaletteWhiteOut
 		disable_ints
 		lea	(vdp_control_port).l,a6
@@ -3234,7 +3234,7 @@ GM_Special:
 		clr.w	(v_ssangle).w	; set stage angle to "upright"
 		move.w	#$40,(v_ssrotate).w ; set stage rotation speed
 		move.w	#bgm_SS,d0
-		bsr.w	PlaySound	; play special stage BG	music
+		bsr.w	QueueSound1	; play special stage BG	music
 		move.w	#0,(v_btnpushtime1).w
 		lea	(DemoDataPtr).l,a1
 		moveq	#6,d0
@@ -3338,7 +3338,7 @@ loc_47D4:
 		mulu.w	#10,d0		; multiply rings by 10
 		move.w	d0,(v_ringbonus).w ; set rings bonus
 		move.w	#bgm_GotThrough,d0
-		jsr	(PlaySound_Special).l	 ; play end-of-level music
+		jsr	(QueueSound2).l	 ; play end-of-level music
 
 		clearRAM v_objspace
 
@@ -3356,7 +3356,7 @@ SS_NormalExit:
 		tst.l	(v_plc_buffer).w
 		bne.s	SS_NormalExit
 		move.w	#sfx_EnterSS,d0
-		bsr.w	PlaySound_Special ; play special stage exit sound
+		bsr.w	QueueSound2 ; play special stage exit sound
 		bsr.w	PaletteWhiteOut
 		rts	
 ; ===========================================================================
@@ -3749,7 +3749,7 @@ GM_Continue:
 		moveq	#palid_Continue,d0
 		bsr.w	PalLoad_Fade	; load continue	screen palette
 		move.b	#bgm_Continue,d0
-		bsr.w	PlaySound	; play continue	music
+		bsr.w	QueueSound1	; play continue	music
 		move.w	#659,(v_demolength).w ; set time delay to 11 seconds
 		clr.l	(v_screenposx).w
 		move.l	#$1000000,(v_screenposy).w
@@ -3820,7 +3820,7 @@ Map_ContScr:	include	"_maps/Continue Screen.asm"
 
 GM_Ending:
 		move.b	#bgm_Stop,d0
-		bsr.w	PlaySound_Special ; stop music
+		bsr.w	QueueSound2 ; stop music
 		bsr.w	PaletteFadeOut
 
 		clearRAM v_objspace
@@ -3866,7 +3866,7 @@ End_LoadData:
 		moveq	#palid_Sonic,d0
 		bsr.w	PalLoad_Fade	; load Sonic's palette
 		move.w	#bgm_Ending,d0
-		bsr.w	PlaySound	; play ending sequence music
+		bsr.w	QueueSound1	; play ending sequence music
 		btst	#bitA,(v_jpadhold1).w ; is button A pressed?
 		beq.s	End_LoadSonic	; if not, branch
 		move.b	#1,(f_debugmode).w ; enable debug mode
@@ -3927,7 +3927,7 @@ End_MainLoop:
 
 		move.b	#id_Credits,(v_gamemode).w ; goto credits
 		move.b	#bgm_Credits,d0
-		bsr.w	PlaySound_Special ; play credits music
+		bsr.w	QueueSound2 ; play credits music
 		move.w	#0,(v_creditsnum).w ; set credits index number to 0
 		rts	
 ; ===========================================================================
@@ -5599,7 +5599,7 @@ loc_84EE:
 loc_84F2:
 		bsr.w	DisplaySprite
 		move.w	#sfx_Collapse,d0
-		jmp	(PlaySound_Special).l	; play collapsing sound
+		jmp	(QueueSound2).l	; play collapsing sound
 ; ===========================================================================
 ; ---------------------------------------------------------------------------
 ; Disintegration data for collapsing ledges (MZ, SLZ, SBZ)
@@ -7163,7 +7163,7 @@ ResumeMusic:
 .playselected:
 		endif
 
-		jsr	(PlaySound).l
+		jsr	(QueueSound1).l
 
 .over12:
 		move.w	#30,(v_air).w	; reset air to 30 seconds
@@ -8288,7 +8288,7 @@ SS_AniEmeraldSparks:
 		clr.l	4(a0)
 		move.b	#4,(v_player+obRoutine).w
 		move.w	#sfx_SSGoal,d0
-		jsr	(PlaySound_Special).l	; play special stage GOAL sound
+		jsr	(QueueSound2).l	; play special stage GOAL sound
 
 locret_1B60C:
 		rts	
@@ -8491,7 +8491,7 @@ AddPoints:
 			addq.b	#1,(v_lives).w ; give extra life
 			addq.b	#1,(f_lifecount).w
 			move.w	#bgm_ExtraLife,d0
-			jmp	(PlaySound).l
+			jmp	(QueueSound1).l
 		endif
 
 .locret_1C6B6:


### PR DESCRIPTION
Running these routines queues the sound ID into a buffer, which SMPS soon reads within the V-Int routine. SMPS has three of these buffers (one of which being broken in Sonic 1's version). This can be used to play multiple sound effects in one frame, or queue both a BGM and SFX in a single frame. Most often, the first one's used for BGM, and the second's used for SFX. Even in the source code, they're labelled as `bgmset` and `soundset`. Of course, the game doesn't always follow this, and BGM/SFX can be used interchangeably between the two buffers. If the third buffer was fixed, which the FixBugs command does do, this third buffer could be used as well for this stuff.

The terminology for "Special" confused me here. Special sound effects, outside of this terminology, follow sound effects between the D0 - DF range. They're not stopped by the "stop sound effects" command (E1), but can be stopped by their own command (E2), which does not stop sound effects between A0 - CF.

In this push, I've renamed "PlaySound" to "QueueSoundBuf1", "PlaySound_Special" to "QueueSoundBuf2", and "PlaySound_Unused" to "QueueSoundBuf3". This doesn't exactly follow what the game or source code does, but would lead to less confusion about the limitations for the user.