### PR TITLE
Simplified object pointer definitions through a macro

### DIFF
--- a/_inc/Object Pointers.asm
+++ b/_inc/Object Pointers.asm
@@ -1,287 +1,162 @@
 ; ---------------------------------------------------------------------------
 ; Object pointers
 ; ---------------------------------------------------------------------------
-ptr_SonicPlayer:	dc.l SonicPlayer	; $01
-ptr_Obj02:		dc.l NullObject
-ptr_Obj03:		dc.l NullObject
-ptr_Obj04:		dc.l NullObject
-ptr_Obj05:		dc.l NullObject
-ptr_Obj06:		dc.l NullObject
-ptr_Obj07:		dc.l NullObject
-ptr_Splash:		dc.l Splash		; $08
-ptr_SonicSpecial:	dc.l SonicSpecial
-ptr_DrownCount:		dc.l DrownCount
-ptr_Pole:		dc.l Pole
-ptr_FlapDoor:		dc.l FlapDoor
-ptr_Signpost:		dc.l Signpost
-ptr_TitleSonic:		dc.l TitleSonic
-ptr_PSBTM:		dc.l PSBTM
-ptr_Obj10:		dc.l Obj10		; $10
-ptr_Bridge:		dc.l Bridge
-ptr_SpinningLight:	dc.l SpinningLight
-ptr_LavaMaker:		dc.l LavaMaker
-ptr_LavaBall:		dc.l LavaBall
-ptr_SwingingPlatform:	dc.l SwingingPlatform
-ptr_Harpoon:		dc.l Harpoon
-ptr_Helix:		dc.l Helix
-ptr_BasicPlatform:	dc.l BasicPlatform	; $18
-ptr_Obj19:		dc.l Obj19
-ptr_CollapseLedge:	dc.l CollapseLedge
-ptr_WaterSurface:	dc.l WaterSurface
-ptr_Scenery:		dc.l Scenery
-ptr_MagicSwitch:	dc.l MagicSwitch
-ptr_BallHog:		dc.l BallHog
-ptr_Crabmeat:		dc.l Crabmeat
-ptr_Cannonball:		dc.l Cannonball		; $20
-ptr_HUD:		dc.l HUD
-ptr_BuzzBomber:		dc.l BuzzBomber
-ptr_Missile:		dc.l Missile
-ptr_MissileDissolve:	dc.l MissileDissolve
-ptr_Rings:		dc.l Rings
-ptr_Monitor:		dc.l Monitor
-ptr_ExplosionItem:	dc.l ExplosionItem
-ptr_Animals:		dc.l Animals		; $28
-ptr_Points:		dc.l Points
-ptr_AutoDoor:		dc.l AutoDoor
-ptr_Chopper:		dc.l Chopper
-ptr_Jaws:		dc.l Jaws
-ptr_Burrobot:		dc.l Burrobot
-ptr_PowerUp:		dc.l PowerUp
-ptr_LargeGrass:		dc.l LargeGrass
-ptr_GlassBlock:		dc.l GlassBlock		; $30
-ptr_ChainStomp:		dc.l ChainStomp
-ptr_Button:		dc.l Button
-ptr_PushBlock:		dc.l PushBlock
-ptr_TitleCard:		dc.l TitleCard
-ptr_GrassFire:		dc.l GrassFire
-ptr_Spikes:		dc.l Spikes
-ptr_RingLoss:		dc.l RingLoss
-ptr_ShieldItem:		dc.l ShieldItem		; $38
-ptr_GameOverCard:	dc.l GameOverCard
-ptr_GotThroughCard:	dc.l GotThroughCard
-ptr_PurpleRock:		dc.l PurpleRock
-ptr_SmashWall:		dc.l SmashWall
-ptr_BossGreenHill:	dc.l BossGreenHill
-ptr_Prison:		dc.l Prison
-ptr_ExplosionBomb:	dc.l ExplosionBomb
-ptr_MotoBug:		dc.l MotoBug		; $40
-ptr_Springs:		dc.l Springs
-ptr_Newtron:		dc.l Newtron
-ptr_Roller:		dc.l Roller
-ptr_EdgeWalls:		dc.l EdgeWalls
-ptr_SideStomp:		dc.l SideStomp
-ptr_MarbleBrick:	dc.l MarbleBrick
-ptr_Bumper:		dc.l Bumper
-ptr_BossBall:		dc.l BossBall		; $48
-ptr_WaterSound:		dc.l WaterSound
-ptr_VanishSonic:	dc.l VanishSonic
-ptr_GiantRing:		dc.l GiantRing
-ptr_GeyserMaker:	dc.l GeyserMaker
-ptr_LavaGeyser:		dc.l LavaGeyser
-ptr_LavaWall:		dc.l LavaWall
-ptr_Obj4F:		dc.l Obj4F
-ptr_Yadrin:		dc.l Yadrin		; $50
-ptr_SmashBlock:		dc.l SmashBlock
-ptr_MovingBlock:	dc.l MovingBlock
-ptr_CollapseFloor:	dc.l CollapseFloor
-ptr_LavaTag:		dc.l LavaTag
-ptr_Basaran:		dc.l Basaran
-ptr_FloatingBlock:	dc.l FloatingBlock
-ptr_SpikeBall:		dc.l SpikeBall
-ptr_BigSpikeBall:	dc.l BigSpikeBall	; $58
-ptr_Elevator:		dc.l Elevator
-ptr_CirclingPlatform:	dc.l CirclingPlatform
-ptr_Staircase:		dc.l Staircase
-ptr_Pylon:		dc.l Pylon
-ptr_Fan:		dc.l Fan
-ptr_Seesaw:		dc.l Seesaw
-ptr_Bomb:		dc.l Bomb
-ptr_Orbinaut:		dc.l Orbinaut		; $60
-ptr_LabyrinthBlock:	dc.l LabyrinthBlock
-ptr_Gargoyle:		dc.l Gargoyle
-ptr_LabyrinthConvey:	dc.l LabyrinthConvey
-ptr_Bubble:		dc.l Bubble
-ptr_Waterfall:		dc.l Waterfall
-ptr_Junction:		dc.l Junction
-ptr_RunningDisc:	dc.l RunningDisc
-ptr_Conveyor:		dc.l Conveyor		; $68
-ptr_SpinPlatform:	dc.l SpinPlatform
-ptr_Saws:		dc.l Saws
-ptr_ScrapStomp:		dc.l ScrapStomp
-ptr_VanishPlatform:	dc.l VanishPlatform
-ptr_Flamethrower:	dc.l Flamethrower
-ptr_Electro:		dc.l Electro
-ptr_SpinConvey:		dc.l SpinConvey
-ptr_Girder:		dc.l Girder		; $70
-ptr_Invisibarrier:	dc.l Invisibarrier
-ptr_Teleport:		dc.l Teleport
-ptr_BossMarble:		dc.l BossMarble
-ptr_BossFire:		dc.l BossFire
-ptr_BossSpringYard:	dc.l BossSpringYard
-ptr_BossBlock:		dc.l BossBlock
-ptr_BossLabyrinth:	dc.l BossLabyrinth
-ptr_Caterkiller:	dc.l Caterkiller	; $78
-ptr_Lamppost:		dc.l Lamppost
-ptr_BossStarLight:	dc.l BossStarLight
-ptr_BossSpikeball:	dc.l BossSpikeball
-ptr_RingFlash:		dc.l RingFlash
-ptr_HiddenBonus:	dc.l HiddenBonus
-ptr_SSResult:		dc.l SSResult
-ptr_SSRChaos:		dc.l SSRChaos
-ptr_ContScrItem:	dc.l ContScrItem	; $80
-ptr_ContSonic:		dc.l ContSonic
-ptr_ScrapEggman:	dc.l ScrapEggman
-ptr_FalseFloor:		dc.l FalseFloor
-ptr_EggmanCylinder:	dc.l EggmanCylinder
-ptr_BossFinal:		dc.l BossFinal
-ptr_BossPlasma:		dc.l BossPlasma
-ptr_EndSonic:		dc.l EndSonic
-ptr_EndChaos:		dc.l EndChaos		; $88
-ptr_EndSTH:		dc.l EndSTH
-ptr_CreditsText:	dc.l CreditsText
-ptr_EndEggman:		dc.l EndEggman
-ptr_TryChaos:		dc.l TryChaos
+
+objptr:	macro label
+	if "label"<>"NullObject"
+		ptr_label:
+		id_label:	equ ((ptr_label-Obj_Index)/4)+1
+	endif
+		dc.l	label
+		endm
+
+; ---------------------------------------------------------------------------
+
+		objptr	SonicPlayer		; $01
+		objptr	NullObject
+		objptr	NullObject
+		objptr	NullObject
+		objptr	NullObject
+		objptr	NullObject
+		objptr	NullObject
+		objptr	Splash			; $08
+		objptr	SonicSpecial
+		objptr	DrownCount
+		objptr	Pole
+		objptr	FlapDoor
+		objptr	Signpost
+		objptr	TitleSonic
+		objptr	PSBTM
+		objptr	Obj10			; $10
+		objptr	Bridge
+		objptr	SpinningLight
+		objptr	LavaMaker
+		objptr	LavaBall
+		objptr	SwingingPlatform
+		objptr	Harpoon
+		objptr	Helix
+		objptr	BasicPlatform		; $18
+		objptr	Obj19
+		objptr	CollapseLedge
+		objptr	WaterSurface
+		objptr	Scenery
+		objptr	MagicSwitch
+		objptr	BallHog
+		objptr	Crabmeat
+		objptr	Cannonball		; $20
+		objptr	HUD
+		objptr	BuzzBomber
+		objptr	Missile
+		objptr	MissileDissolve
+		objptr	Rings
+		objptr	Monitor
+		objptr	ExplosionItem
+		objptr	Animals			; $28
+		objptr	Points
+		objptr	AutoDoor
+		objptr	Chopper
+		objptr	Jaws
+		objptr	Burrobot
+		objptr	PowerUp
+		objptr	LargeGrass
+		objptr	GlassBlock		; $30
+		objptr	ChainStomp
+		objptr	Button
+		objptr	PushBlock
+		objptr	TitleCard
+		objptr	GrassFire
+		objptr	Spikes
+		objptr	RingLoss
+		objptr	ShieldItem		; $38
+		objptr	GameOverCard
+		objptr	GotThroughCard
+		objptr	PurpleRock
+		objptr	SmashWall
+		objptr	BossGreenHill
+		objptr	Prison
+		objptr	ExplosionBomb
+		objptr	MotoBug			; $40
+		objptr	Springs
+		objptr	Newtron
+		objptr	Roller
+		objptr	EdgeWalls
+		objptr	SideStomp
+		objptr	MarbleBrick
+		objptr	Bumper
+		objptr	BossBall		; $48
+		objptr	WaterSound
+		objptr	VanishSonic
+		objptr	GiantRing
+		objptr	GeyserMaker
+		objptr	LavaGeyser
+		objptr	LavaWall
+		objptr	Obj4F
+		objptr	Yadrin			; $50
+		objptr	SmashBlock
+		objptr	MovingBlock
+		objptr	CollapseFloor
+		objptr	LavaTag
+		objptr	Basaran
+		objptr	FloatingBlock
+		objptr	SpikeBall
+		objptr	BigSpikeBall		; $58
+		objptr	Elevator
+		objptr	CirclingPlatform
+		objptr	Staircase
+		objptr	Pylon
+		objptr	Fan
+		objptr	Seesaw
+		objptr	Bomb
+		objptr	Orbinaut		; $60
+		objptr	LabyrinthBlock
+		objptr	Gargoyle
+		objptr	LabyrinthConvey
+		objptr	Bubble
+		objptr	Waterfall
+		objptr	Junction
+		objptr	RunningDisc
+		objptr	Conveyor		; $68
+		objptr	SpinPlatform
+		objptr	Saws
+		objptr	ScrapStomp
+		objptr	VanishPlatform
+		objptr	Flamethrower
+		objptr	Electro
+		objptr	SpinConvey
+		objptr	Girder			; $70
+		objptr	Invisibarrier
+		objptr	Teleport
+		objptr	BossMarble
+		objptr	BossFire
+		objptr	BossSpringYard
+		objptr	BossBlock
+		objptr	BossLabyrinth
+		objptr	Caterkiller		; $78
+		objptr	Lamppost
+		objptr	BossStarLight
+		objptr	BossSpikeball
+		objptr	RingFlash
+		objptr	HiddenBonus
+		objptr	SSResult
+		objptr	SSRChaos
+		objptr	ContScrItem		; $80
+		objptr	ContSonic
+		objptr	ScrapEggman
+		objptr	FalseFloor
+		objptr	EggmanCylinder
+		objptr	BossFinal
+		objptr	BossPlasma
+		objptr	EndSonic
+		objptr	EndChaos		; $88
+		objptr	EndSTH
+		objptr	CreditsText
+		objptr	EndEggman
+		objptr	TryChaos
+
+; ---------------------------------------------------------------------------
 
 NullObject:
-		;jmp	(DeleteObject).l	; It would be safer to have this instruction here, but instead it just falls through to ObjectFall
-
-id_SonicPlayer:		equ ((ptr_SonicPlayer-Obj_Index)/4)+1		; $01
-id_Obj02:		equ ((ptr_Obj02-Obj_Index)/4)+1
-id_Obj03:		equ ((ptr_Obj03-Obj_Index)/4)+1
-id_Obj04:		equ ((ptr_Obj04-Obj_Index)/4)+1
-id_Obj05:		equ ((ptr_Obj05-Obj_Index)/4)+1
-id_Obj06:		equ ((ptr_Obj06-Obj_Index)/4)+1
-id_Obj07:		equ ((ptr_Obj07-Obj_Index)/4)+1
-id_Splash:		equ ((ptr_Splash-Obj_Index)/4)+1		; $08
-id_SonicSpecial:	equ ((ptr_SonicSpecial-Obj_Index)/4)+1
-id_DrownCount:		equ ((ptr_DrownCount-Obj_Index)/4)+1
-id_Pole:		equ ((ptr_Pole-Obj_Index)/4)+1
-id_FlapDoor:		equ ((ptr_FlapDoor-Obj_Index)/4)+1
-id_Signpost:		equ ((ptr_Signpost-Obj_Index)/4)+1
-id_TitleSonic:		equ ((ptr_TitleSonic-Obj_Index)/4)+1
-id_PSBTM:		equ ((ptr_PSBTM-Obj_Index)/4)+1
-id_Obj10:		equ ((ptr_Obj10-Obj_Index)/4)+1			; $10
-id_Bridge:		equ ((ptr_Bridge-Obj_Index)/4)+1
-id_SpinningLight:	equ ((ptr_SpinningLight-Obj_Index)/4)+1
-id_LavaMaker:		equ ((ptr_LavaMaker-Obj_Index)/4)+1
-id_LavaBall:		equ ((ptr_LavaBall-Obj_Index)/4)+1
-id_SwingingPlatform:	equ ((ptr_SwingingPlatform-Obj_Index)/4)+1
-id_Harpoon:		equ ((ptr_Harpoon-Obj_Index)/4)+1
-id_Helix:		equ ((ptr_Helix-Obj_Index)/4)+1
-id_BasicPlatform:	equ ((ptr_BasicPlatform-Obj_Index)/4)+1		; $18
-id_Obj19:		equ ((ptr_Obj19-Obj_Index)/4)+1
-id_CollapseLedge:	equ ((ptr_CollapseLedge-Obj_Index)/4)+1
-id_WaterSurface:	equ ((ptr_WaterSurface-Obj_Index)/4)+1
-id_Scenery:		equ ((ptr_Scenery-Obj_Index)/4)+1
-id_MagicSwitch:		equ ((ptr_MagicSwitch-Obj_Index)/4)+1
-id_BallHog:		equ ((ptr_BallHog-Obj_Index)/4)+1
-id_Crabmeat:		equ ((ptr_Crabmeat-Obj_Index)/4)+1
-id_Cannonball:		equ ((ptr_Cannonball-Obj_Index)/4)+1		; $20
-id_HUD:			equ ((ptr_HUD-Obj_Index)/4)+1
-id_BuzzBomber:		equ ((ptr_BuzzBomber-Obj_Index)/4)+1
-id_Missile:		equ ((ptr_Missile-Obj_Index)/4)+1
-id_MissileDissolve:	equ ((ptr_MissileDissolve-Obj_Index)/4)+1
-id_Rings:		equ ((ptr_Rings-Obj_Index)/4)+1
-id_Monitor:		equ ((ptr_Monitor-Obj_Index)/4)+1
-id_ExplosionItem:	equ ((ptr_ExplosionItem-Obj_Index)/4)+1
-id_Animals:		equ ((ptr_Animals-Obj_Index)/4)+1		; $28
-id_Points:		equ ((ptr_Points-Obj_Index)/4)+1
-id_AutoDoor:		equ ((ptr_AutoDoor-Obj_Index)/4)+1
-id_Chopper:		equ ((ptr_Chopper-Obj_Index)/4)+1
-id_Jaws:		equ ((ptr_Jaws-Obj_Index)/4)+1
-id_Burrobot:		equ ((ptr_Burrobot-Obj_Index)/4)+1
-id_PowerUp:		equ ((ptr_PowerUp-Obj_Index)/4)+1
-id_LargeGrass:		equ ((ptr_LargeGrass-Obj_Index)/4)+1
-id_GlassBlock:		equ ((ptr_GlassBlock-Obj_Index)/4)+1		; $30
-id_ChainStomp:		equ ((ptr_ChainStomp-Obj_Index)/4)+1
-id_Button:		equ ((ptr_Button-Obj_Index)/4)+1
-id_PushBlock:		equ ((ptr_PushBlock-Obj_Index)/4)+1
-id_TitleCard:		equ ((ptr_TitleCard-Obj_Index)/4)+1
-id_GrassFire:		equ ((ptr_GrassFire-Obj_Index)/4)+1
-id_Spikes:		equ ((ptr_Spikes-Obj_Index)/4)+1
-id_RingLoss:		equ ((ptr_RingLoss-Obj_Index)/4)+1
-id_ShieldItem:		equ ((ptr_ShieldItem-Obj_Index)/4)+1		; $38
-id_GameOverCard:	equ ((ptr_GameOverCard-Obj_Index)/4)+1
-id_GotThroughCard:	equ ((ptr_GotThroughCard-Obj_Index)/4)+1
-id_PurpleRock:		equ ((ptr_PurpleRock-Obj_Index)/4)+1
-id_SmashWall:		equ ((ptr_SmashWall-Obj_Index)/4)+1
-id_BossGreenHill:	equ ((ptr_BossGreenHill-Obj_Index)/4)+1
-id_Prison:		equ ((ptr_Prison-Obj_Index)/4)+1
-id_ExplosionBomb:	equ ((ptr_ExplosionBomb-Obj_Index)/4)+1
-id_MotoBug:		equ ((ptr_MotoBug-Obj_Index)/4)+1		; $40
-id_Springs:		equ ((ptr_Springs-Obj_Index)/4)+1
-id_Newtron:		equ ((ptr_Newtron-Obj_Index)/4)+1
-id_Roller:		equ ((ptr_Roller-Obj_Index)/4)+1
-id_EdgeWalls:		equ ((ptr_EdgeWalls-Obj_Index)/4)+1
-id_SideStomp:		equ ((ptr_SideStomp-Obj_Index)/4)+1
-id_MarbleBrick:		equ ((ptr_MarbleBrick-Obj_Index)/4)+1
-id_Bumper:		equ ((ptr_Bumper-Obj_Index)/4)+1
-id_BossBall:		equ ((ptr_BossBall-Obj_Index)/4)+1		; $48
-id_WaterSound:		equ ((ptr_WaterSound-Obj_Index)/4)+1
-id_VanishSonic:		equ ((ptr_VanishSonic-Obj_Index)/4)+1
-id_GiantRing:		equ ((ptr_GiantRing-Obj_Index)/4)+1
-id_GeyserMaker:		equ ((ptr_GeyserMaker-Obj_Index)/4)+1
-id_LavaGeyser:		equ ((ptr_LavaGeyser-Obj_Index)/4)+1
-id_LavaWall:		equ ((ptr_LavaWall-Obj_Index)/4)+1
-id_Obj4F:		equ ((ptr_Obj4F-Obj_Index)/4)+1
-id_Yadrin:		equ ((ptr_Yadrin-Obj_Index)/4)+1		; $50
-id_SmashBlock:		equ ((ptr_SmashBlock-Obj_Index)/4)+1
-id_MovingBlock:		equ ((ptr_MovingBlock-Obj_Index)/4)+1
-id_CollapseFloor:	equ ((ptr_CollapseFloor-Obj_Index)/4)+1
-id_LavaTag:		equ ((ptr_LavaTag-Obj_Index)/4)+1
-id_Basaran:		equ ((ptr_Basaran-Obj_Index)/4)+1
-id_FloatingBlock:	equ ((ptr_FloatingBlock-Obj_Index)/4)+1
-id_SpikeBall:		equ ((ptr_SpikeBall-Obj_Index)/4)+1
-id_BigSpikeBall:	equ ((ptr_BigSpikeBall-Obj_Index)/4)+1		; $58
-id_Elevator:		equ ((ptr_Elevator-Obj_Index)/4)+1
-id_CirclingPlatform:	equ ((ptr_CirclingPlatform-Obj_Index)/4)+1
-id_Staircase:		equ ((ptr_Staircase-Obj_Index)/4)+1
-id_Pylon:		equ ((ptr_Pylon-Obj_Index)/4)+1
-id_Fan:			equ ((ptr_Fan-Obj_Index)/4)+1
-id_Seesaw:		equ ((ptr_Seesaw-Obj_Index)/4)+1
-id_Bomb:		equ ((ptr_Bomb-Obj_Index)/4)+1
-id_Orbinaut:		equ ((ptr_Orbinaut-Obj_Index)/4)+1		; $60
-id_LabyrinthBlock:	equ ((ptr_LabyrinthBlock-Obj_Index)/4)+1
-id_Gargoyle:		equ ((ptr_Gargoyle-Obj_Index)/4)+1
-id_LabyrinthConvey:	equ ((ptr_LabyrinthConvey-Obj_Index)/4)+1
-id_Bubble:		equ ((ptr_Bubble-Obj_Index)/4)+1
-id_Waterfall:		equ ((ptr_Waterfall-Obj_Index)/4)+1
-id_Junction:		equ ((ptr_Junction-Obj_Index)/4)+1
-id_RunningDisc:		equ ((ptr_RunningDisc-Obj_Index)/4)+1
-id_Conveyor:		equ ((ptr_Conveyor-Obj_Index)/4)+1		; $68
-id_SpinPlatform:	equ ((ptr_SpinPlatform-Obj_Index)/4)+1
-id_Saws:		equ ((ptr_Saws-Obj_Index)/4)+1
-id_ScrapStomp:		equ ((ptr_ScrapStomp-Obj_Index)/4)+1
-id_VanishPlatform:	equ ((ptr_VanishPlatform-Obj_Index)/4)+1
-id_Flamethrower:	equ ((ptr_Flamethrower-Obj_Index)/4)+1
-id_Electro:		equ ((ptr_Electro-Obj_Index)/4)+1
-id_SpinConvey:		equ ((ptr_SpinConvey-Obj_Index)/4)+1
-id_Girder:		equ ((ptr_Girder-Obj_Index)/4)+1		; $70
-id_Invisibarrier:	equ ((ptr_Invisibarrier-Obj_Index)/4)+1
-id_Teleport:		equ ((ptr_Teleport-Obj_Index)/4)+1
-id_BossMarble:		equ ((ptr_BossMarble-Obj_Index)/4)+1
-id_BossFire:		equ ((ptr_BossFire-Obj_Index)/4)+1
-id_BossSpringYard:	equ ((ptr_BossSpringYard-Obj_Index)/4)+1
-id_BossBlock:		equ ((ptr_BossBlock-Obj_Index)/4)+1
-id_BossLabyrinth:	equ ((ptr_BossLabyrinth-Obj_Index)/4)+1
-id_Caterkiller:		equ ((ptr_Caterkiller-Obj_Index)/4)+1		; $78
-id_Lamppost:		equ ((ptr_Lamppost-Obj_Index)/4)+1
-id_BossStarLight:	equ ((ptr_BossStarLight-Obj_Index)/4)+1
-id_BossSpikeball:	equ ((ptr_BossSpikeball-Obj_Index)/4)+1
-id_RingFlash:		equ ((ptr_RingFlash-Obj_Index)/4)+1
-id_HiddenBonus:		equ ((ptr_HiddenBonus-Obj_Index)/4)+1
-id_SSResult:		equ ((ptr_SSResult-Obj_Index)/4)+1
-id_SSRChaos:		equ ((ptr_SSRChaos-Obj_Index)/4)+1
-id_ContScrItem:		equ ((ptr_ContScrItem-Obj_Index)/4)+1		; $80
-id_ContSonic:		equ ((ptr_ContSonic-Obj_Index)/4)+1
-id_ScrapEggman:		equ ((ptr_ScrapEggman-Obj_Index)/4)+1
-id_FalseFloor:		equ ((ptr_FalseFloor-Obj_Index)/4)+1
-id_EggmanCylinder:	equ ((ptr_EggmanCylinder-Obj_Index)/4)+1
-id_BossFinal:		equ ((ptr_BossFinal-Obj_Index)/4)+1
-id_BossPlasma:		equ ((ptr_BossPlasma-Obj_Index)/4)+1
-id_EndSonic:		equ ((ptr_EndSonic-Obj_Index)/4)+1
-id_EndChaos:		equ ((ptr_EndChaos-Obj_Index)/4)+1		; $88
-id_EndSTH:		equ ((ptr_EndSTH-Obj_Index)/4)+1
-id_CreditsText:		equ ((ptr_CreditsText-Obj_Index)/4)+1
-id_EndEggman:		equ ((ptr_EndEggman-Obj_Index)/4)+1
-id_TryChaos:		equ ((ptr_TryChaos-Obj_Index)/4)+1
+	if FixBugs
+		; It would be safer to have this instruction here, otherwise it would just fall through to ObjectFall
+		jmp	(DeleteObject).l
+	endif

--- a/_inc/Object Pointers.asm
+++ b/_inc/Object Pointers.asm
@@ -1,157 +1,158 @@
 ; ---------------------------------------------------------------------------
 ; Object pointers
 ; ---------------------------------------------------------------------------
+Obj_Index:
 
-objptr:	macro label
-	if "label"<>"NullObject"
-		ptr_label:
-		id_label:	equ ((ptr_label-Obj_Index)/4)+1
-	endif
-		dc.l	label
-		endm
+objptr:	macro objectpointer,{INTLABEL},{GLOBALSYMBOLS}
+__LABEL__: = ((*-Obj_Index)/4)+1
+	dc.l	objectpointer
+	endm
 
 ; ---------------------------------------------------------------------------
+; ID label:	non-zero index byte (see ID value)
+; Object label:	main label to the actual object source
 
-		objptr	SonicPlayer		; $01
-		objptr	NullObject
-		objptr	NullObject
-		objptr	NullObject
-		objptr	NullObject
-		objptr	NullObject
-		objptr	NullObject
-		objptr	Splash			; $08
-		objptr	SonicSpecial
-		objptr	DrownCount
-		objptr	Pole
-		objptr	FlapDoor
-		objptr	Signpost
-		objptr	TitleSonic
-		objptr	PSBTM
-		objptr	Obj10			; $10
-		objptr	Bridge
-		objptr	SpinningLight
-		objptr	LavaMaker
-		objptr	LavaBall
-		objptr	SwingingPlatform
-		objptr	Harpoon
-		objptr	Helix
-		objptr	BasicPlatform		; $18
-		objptr	Obj19
-		objptr	CollapseLedge
-		objptr	WaterSurface
-		objptr	Scenery
-		objptr	MagicSwitch
-		objptr	BallHog
-		objptr	Crabmeat
-		objptr	Cannonball		; $20
-		objptr	HUD
-		objptr	BuzzBomber
-		objptr	Missile
-		objptr	MissileDissolve
-		objptr	Rings
-		objptr	Monitor
-		objptr	ExplosionItem
-		objptr	Animals			; $28
-		objptr	Points
-		objptr	AutoDoor
-		objptr	Chopper
-		objptr	Jaws
-		objptr	Burrobot
-		objptr	PowerUp
-		objptr	LargeGrass
-		objptr	GlassBlock		; $30
-		objptr	ChainStomp
-		objptr	Button
-		objptr	PushBlock
-		objptr	TitleCard
-		objptr	GrassFire
-		objptr	Spikes
-		objptr	RingLoss
-		objptr	ShieldItem		; $38
-		objptr	GameOverCard
-		objptr	GotThroughCard
-		objptr	PurpleRock
-		objptr	SmashWall
-		objptr	BossGreenHill
-		objptr	Prison
-		objptr	ExplosionBomb
-		objptr	MotoBug			; $40
-		objptr	Springs
-		objptr	Newtron
-		objptr	Roller
-		objptr	EdgeWalls
-		objptr	SideStomp
-		objptr	MarbleBrick
-		objptr	Bumper
-		objptr	BossBall		; $48
-		objptr	WaterSound
-		objptr	VanishSonic
-		objptr	GiantRing
-		objptr	GeyserMaker
-		objptr	LavaGeyser
-		objptr	LavaWall
-		objptr	Obj4F
-		objptr	Yadrin			; $50
-		objptr	SmashBlock
-		objptr	MovingBlock
-		objptr	CollapseFloor
-		objptr	LavaTag
-		objptr	Basaran
-		objptr	FloatingBlock
-		objptr	SpikeBall
-		objptr	BigSpikeBall		; $58
-		objptr	Elevator
-		objptr	CirclingPlatform
-		objptr	Staircase
-		objptr	Pylon
-		objptr	Fan
-		objptr	Seesaw
-		objptr	Bomb
-		objptr	Orbinaut		; $60
-		objptr	LabyrinthBlock
-		objptr	Gargoyle
-		objptr	LabyrinthConvey
-		objptr	Bubble
-		objptr	Waterfall
-		objptr	Junction
-		objptr	RunningDisc
-		objptr	Conveyor		; $68
-		objptr	SpinPlatform
-		objptr	Saws
-		objptr	ScrapStomp
-		objptr	VanishPlatform
-		objptr	Flamethrower
-		objptr	Electro
-		objptr	SpinConvey
-		objptr	Girder			; $70
-		objptr	Invisibarrier
-		objptr	Teleport
-		objptr	BossMarble
-		objptr	BossFire
-		objptr	BossSpringYard
-		objptr	BossBlock
-		objptr	BossLabyrinth
-		objptr	Caterkiller		; $78
-		objptr	Lamppost
-		objptr	BossStarLight
-		objptr	BossSpikeball
-		objptr	RingFlash
-		objptr	HiddenBonus
-		objptr	SSResult
-		objptr	SSRChaos
-		objptr	ContScrItem		; $80
-		objptr	ContSonic
-		objptr	ScrapEggman
-		objptr	FalseFloor
-		objptr	EggmanCylinder
-		objptr	BossFinal
-		objptr	BossPlasma
-		objptr	EndSonic
-		objptr	EndChaos		; $88
-		objptr	EndSTH
-		objptr	CreditsText
-		objptr	EndEggman
-		objptr	TryChaos
+; ID label			Object label		  ID value
+id_SonicPlayer:		objptr	SonicPlayer		; 01
+id_Obj02:		objptr	NullObject		; 02
+id_Obj03:		objptr	NullObject		; 03
+id_Obj04:		objptr	NullObject		; 04
+id_Obj05:		objptr	NullObject		; 05
+id_Obj06:		objptr	NullObject		; 06
+id_Obj07:		objptr	NullObject		; 07
+id_Splash:		objptr	Splash			; 08
+id_SonicSpecial:	objptr	SonicSpecial		; 09
+id_DrownCount:		objptr	DrownCount		; 0A
+id_Pole:		objptr	Pole			; 0B
+id_FlapDoor:		objptr	FlapDoor		; 0C
+id_Signpost:		objptr	Signpost		; 0D
+id_TitleSonic:		objptr	TitleSonic		; 0E
+id_PSBTM:		objptr	PSBTM			; 0F
+id_Obj10:		objptr	Obj10			; 10
+id_Bridge:		objptr	Bridge			; 11
+id_SpinningLight:	objptr	SpinningLight		; 12
+id_LavaMaker:		objptr	LavaMaker		; 13
+id_LavaBall:		objptr	LavaBall		; 14
+id_SwingingPlatform:	objptr	SwingingPlatform	; 15
+id_Harpoon:		objptr	Harpoon			; 16
+id_Helix:		objptr	Helix			; 17
+id_BasicPlatform:	objptr	BasicPlatform		; 18
+id_Obj19:		objptr	Obj19			; 19
+id_CollapseLedge:	objptr	CollapseLedge		; 1A
+id_WaterSurface:	objptr	WaterSurface		; 1B
+id_Scenery:		objptr	Scenery			; 1C
+id_MagicSwitch:		objptr	MagicSwitch		; 1D
+id_BallHog:		objptr	BallHog			; 1E
+id_Crabmeat:		objptr	Crabmeat		; 1F
+id_Cannonball:		objptr	Cannonball		; 20
+id_HUD:			objptr	HUD			; 21
+id_BuzzBomber:		objptr	BuzzBomber		; 22
+id_Missile:		objptr	Missile			; 23
+id_MissileDissolve:	objptr	MissileDissolve		; 24
+id_Rings:		objptr	Rings			; 25
+id_Monitor:		objptr	Monitor			; 26
+id_ExplosionItem:	objptr	ExplosionItem		; 27
+id_Animals:		objptr	Animals			; 28
+id_Points:		objptr	Points			; 29
+id_AutoDoor:		objptr	AutoDoor		; 2A
+id_Chopper:		objptr	Chopper			; 2B
+id_Jaws:		objptr	Jaws			; 2C
+id_Burrobot:		objptr	Burrobot		; 2D
+id_PowerUp:		objptr	PowerUp			; 2E
+id_LargeGrass:		objptr	LargeGrass		; 2F
+id_GlassBlock:		objptr	GlassBlock		; 30
+id_ChainStomp:		objptr	ChainStomp		; 31
+id_Button:		objptr	Button			; 32
+id_PushBlock:		objptr	PushBlock		; 33
+id_TitleCard:		objptr	TitleCard		; 34
+id_GrassFire:		objptr	GrassFire		; 35
+id_Spikes:		objptr	Spikes			; 36
+id_RingLoss:		objptr	RingLoss		; 37
+id_ShieldItem:		objptr	ShieldItem		; 38
+id_GameOverCard:	objptr	GameOverCard		; 39
+id_GotThroughCard:	objptr	GotThroughCard		; 3A
+id_PurpleRock:		objptr	PurpleRock		; 3B
+id_SmashWall:		objptr	SmashWall		; 3C
+id_BossGreenHill:	objptr	BossGreenHill		; 3D
+id_Prison:		objptr	Prison			; 3E
+id_ExplosionBomb:	objptr	ExplosionBomb		; 3F
+id_MotoBug:		objptr	MotoBug			; 40
+id_Springs:		objptr	Springs			; 41
+id_Newtron:		objptr	Newtron			; 42
+id_Roller:		objptr	Roller			; 43
+id_EdgeWalls:		objptr	EdgeWalls		; 44
+id_SideStomp:		objptr	SideStomp		; 45
+id_MarbleBrick:		objptr	MarbleBrick		; 46
+id_Bumper:		objptr	Bumper			; 47
+id_BossBall:		objptr	BossBall		; 48
+id_WaterSound:		objptr	WaterSound		; 49
+id_VanishSonic:		objptr	VanishSonic		; 4A
+id_GiantRing:		objptr	GiantRing		; 4B
+id_GeyserMaker:		objptr	GeyserMaker		; 4C
+id_LavaGeyser:		objptr	LavaGeyser		; 4D
+id_LavaWall:		objptr	LavaWall		; 4E
+id_Obj4F:		objptr	Obj4F			; 4F
+id_Yadrin:		objptr	Yadrin			; 50
+id_SmashBlock:		objptr	SmashBlock		; 51
+id_MovingBlock:		objptr	MovingBlock		; 52
+id_CollapseFloor:	objptr	CollapseFloor		; 53
+id_LavaTag:		objptr	LavaTag			; 54
+id_Basaran:		objptr	Basaran			; 55
+id_FloatingBlock:	objptr	FloatingBlock		; 56
+id_SpikeBall:		objptr	SpikeBall		; 57
+id_BigSpikeBall:	objptr	BigSpikeBall		; 58
+id_Elevator:		objptr	Elevator		; 59
+id_CirclingPlatform:	objptr	CirclingPlatform	; 5A
+id_Staircase:		objptr	Staircase		; 5B
+id_Pylon:		objptr	Pylon			; 5C
+id_Fan:			objptr	Fan			; 5D
+id_Seesaw:		objptr	Seesaw			; 5E
+id_Bomb:		objptr	Bomb			; 5F
+id_Orbinaut:		objptr	Orbinaut		; 60
+id_LabyrinthBlock:	objptr	LabyrinthBlock		; 61
+id_Gargoyle:		objptr	Gargoyle		; 62
+id_LabyrinthConvey:	objptr	LabyrinthConvey		; 63
+id_Bubble:		objptr	Bubble			; 64
+id_Waterfall:		objptr	Waterfall		; 65
+id_Junction:		objptr	Junction		; 66
+id_RunningDisc:		objptr	RunningDisc		; 67
+id_Conveyor:		objptr	Conveyor		; 68
+id_SpinPlatform:	objptr	SpinPlatform		; 69
+id_Saws:		objptr	Saws			; 6A
+id_ScrapStomp:		objptr	ScrapStomp		; 6B
+id_VanishPlatform:	objptr	VanishPlatform		; 6C
+id_Flamethrower:	objptr	Flamethrower		; 6D
+id_Electro:		objptr	Electro			; 6E
+id_SpinConvey:		objptr	SpinConvey		; 6F
+id_Girder:		objptr	Girder			; 70
+id_Invisibarrier:	objptr	Invisibarrier		; 71
+id_Teleport:		objptr	Teleport		; 72
+id_BossMarble:		objptr	BossMarble		; 73
+id_BossFire:		objptr	BossFire		; 74
+id_BossSpringYard:	objptr	BossSpringYard		; 75
+id_BossBlock:		objptr	BossBlock		; 76
+id_BossLabyrinth:	objptr	BossLabyrinth		; 77
+id_Caterkiller:		objptr	Caterkiller		; 78
+id_Lamppost:		objptr	Lamppost		; 79
+id_BossStarLight:	objptr	BossStarLight		; 7A
+id_BossSpikeball:	objptr	BossSpikeball		; 7B
+id_RingFlash:		objptr	RingFlash		; 7C
+id_HiddenBonus:		objptr	HiddenBonus		; 7D
+id_SSResult:		objptr	SSResult		; 7E
+id_SSRChaos:		objptr	SSRChaos		; 7F
+id_ContScrItem:		objptr	ContScrItem		; 80
+id_ContSonic:		objptr	ContSonic		; 81
+id_ScrapEggman:		objptr	ScrapEggman		; 82
+id_FalseFloor:		objptr	FalseFloor		; 83
+id_EggmanCylinder:	objptr	EggmanCylinder		; 84
+id_BossFinal:		objptr	BossFinal		; 85
+id_BossPlasma:		objptr	BossPlasma		; 86
+id_EndSonic:		objptr	EndSonic		; 87
+id_EndChaos:		objptr	EndChaos		; 88
+id_EndSTH:		objptr	EndSTH			; 89
+id_CreditsText:		objptr	CreditsText		; 8A
+id_EndEggman:		objptr	EndEggman		; 8B
+id_TryChaos:		objptr	TryChaos		; 8C
 
 ; ---------------------------------------------------------------------------
 

--- a/sonic.asm
+++ b/sonic.asm
@@ -5544,7 +5544,7 @@ loc_D37C:
 ; ---------------------------------------------------------------------------
 ; Object pointers
 ; ---------------------------------------------------------------------------
-Obj_Index:
+; Obj_Index:
 		include	"_inc/Object Pointers.asm"
 
 		include	"_incObj/sub ObjectFall.asm"


### PR DESCRIPTION
This PR introduces a new `objptr` macro to consolidate repetitive code. Instead of manually defining both `ptr_` and `id_`, the macro now handles this automatically.

I had to include an exception for the NullObjects, and I'm not sure if my approach is the best one. Would love some feedback here:

```asm
objptr:	macro label
	if "label"<>"NullObject"
		ptr_label:
		id_label:	equ ((ptr_label-Obj_Index)/4)+1
	endif
		dc.l	label
		endm
```

Here's the variant for ASM68K:
```asm
objptr:	macro label
	if ~strcmp("\label","NullObject")
		ptr_\label:
		id_\label:	equ ((ptr_\label-Obj_Index)/4)+1
	endif
		dc.l	\label
		endm
```
I will commit after this AS PR has gone through.

(Another minor change: The NullObject section at the bottom was also modified to actually enable the call to DeleteObject if FixBugs is enabled, rather than just mentioning it in passing as a comment.)