### PR TITLE
Make DebugMode use art tile functions.

### DIFF
--- a/_incObj/DebugMode.asm
+++ b/_incObj/DebugMode.asm
@@ -181,7 +181,7 @@ Debug_ChgItem:
 		moveq	#0,d0
 		move.w	d0,(v_debuguse).w ; deactivate debug mode
 		move.l	#Map_Sonic,(v_player+obMap).w
-		move.w	#$780,(v_player+obGfx).w
+		move.w	#make_art_tile(ArtTile_Sonic,0,0),(v_player+obGfx).w
 		move.b	d0,(v_player+obAnim).w
 		move.w	d0,obX+2(a0)
 		move.w	d0,obY+2(a0)
@@ -193,7 +193,7 @@ Debug_ChgItem:
 		clr.w	(v_ssangle).w
 		move.w	#$40,(v_ssrotate).w ; set new level rotation speed
 		move.l	#Map_Sonic,(v_player+obMap).w
-		move.w	#$780,(v_player+obGfx).w
+		move.w	#make_art_tile(ArtTile_Sonic,0,0),(v_player+obGfx).w
 		move.b	#id_Roll,(v_player+obAnim).w
 		bset	#2,(v_player+obStatus).w
 		bset	#1,(v_player+obStatus).w


### PR DESCRIPTION
This makes DebugMode consistent with the rest of the objects.