### PR TITLE
Document what this PAL check in VBLANK is doing

### DIFF
--- a/sonic.asm
+++ b/sonic.asm
@@ -624,7 +624,10 @@ VBlank:
 
 		move.w	#$700,d0
 .waitPAL:
-		dbf	d0,.waitPAL ; wait here in a loop doing nothing for a while...
+		; Wait here in a loop doing nothing for a while.
+		; This seems to be a pretty harsh attempt to push CRAM dots outside of the visable view area
+		; due to Sonic 1 not using all the avaiable screen space PAL offers, you would be able to seem them at the bottem.
+		dbf	d0,.waitPAL 
 
 .notPAL:
 		move.b	(v_vbla_routine).w,d0
@@ -679,6 +682,8 @@ VBla_00:
 
 		move.w	#$700,d0
 .waitPAL:
+		; Same as above, this time during a lag frame.
+		; However this only happens if the level is LZ, Sonic 2/3/&K changed this so it runs in any level.
 		dbf	d0,.waitPAL
 
 .notPAL:


### PR DESCRIPTION
Seems to be a "I think harsh" attempt to not show CRAM dots while playing on a PAL system. "Following screenshots use an edited ROM to disable this so you can see the dots show up." 

Blastem (Nightly) and Exodus seems to back this up.
<img width="1002" height="816" alt="dots2" src="https://github.com/user-attachments/assets/92d274b5-959c-4040-8d27-ac58876ad678" />
<img width="802" height="639" alt="dots" src="https://github.com/user-attachments/assets/01f04517-e995-405d-a964-8e8315ef627c" />

If anyone who has a real PAL mega drive wants to test it there as well go for it.