### PR TITLE
Introduced compound zone + act constants

### DIFF
--- a/Constants.asm
+++ b/Constants.asm
@@ -56,7 +56,7 @@ tile_size:	equ 8*8/2	; size of a single 8x8 tile
 chunk_size:	equ $200	; size of a single 256x256 chunk
 plane_size_64x32: equ 64*32*2	; size of plane in 512x256 mode
 
-; Levels
+; Levels (zones)
 id_GHZ:		equ 0
 id_LZ:		equ 1
 id_MZ:		equ 2
@@ -64,7 +64,42 @@ id_SLZ:		equ 3
 id_SYZ:		equ 4
 id_SBZ:		equ 5
 id_EndZ:	equ 6
-id_SS:		equ 7
+id_SS:		equ 7	; only used for level select
+
+; Levels (zone/act word combos)
+act1:		equ 0
+act2:		equ 1
+act3:		equ 2
+act4:		equ 3	; only used for SBZ3/LZ4
+
+id_GHZ_act1:	equ (id_GHZ<<8)+act1	; $0000
+id_GHZ_act2:	equ (id_GHZ<<8)+act2	; $0001
+id_GHZ_act3:	equ (id_GHZ<<8)+act3	; $0002
+
+id_LZ_act1:	equ (id_LZ<<8)+act1	; $0100
+id_LZ_act2:	equ (id_LZ<<8)+act2	; $0101
+id_LZ_act3:	equ (id_LZ<<8)+act3	; $0102
+
+id_MZ_act1:	equ (id_MZ<<8)+act1	; $0200
+id_MZ_act2:	equ (id_MZ<<8)+act2	; $0201
+id_MZ_act3:	equ (id_MZ<<8)+act3	; $0202
+
+id_SLZ_act1:	equ (id_SLZ<<8)+act1	; $0300
+id_SLZ_act2:	equ (id_SLZ<<8)+act2	; $0301
+id_SLZ_act3:	equ (id_SLZ<<8)+act3	; $0302
+
+id_SYZ_act1:	equ (id_SYZ<<8)+act1	; $0400
+id_SYZ_act2:	equ (id_SYZ<<8)+act2	; $0401
+id_SYZ_act3:	equ (id_SYZ<<8)+act3	; $0402
+
+id_SBZ_act1:	equ (id_SBZ<<8)+act1	; $0500
+id_SBZ_act2:	equ (id_SBZ<<8)+act2	; $0501
+;id_SBZ_act3 is ambiguous, could mean LZ4 or FZ
+id_LZ_act4:	equ (id_LZ<<8)+act4	; $0103 (SBZ3)
+id_FZ:		equ (id_SBZ<<8)+act3	; $0502 (real SBZ3)
+
+id_EndZ_good:	equ (id_EndZ<<8)+act1	; $0600 (good ending, all emeralds)
+id_EndZ_bad:	equ (id_EndZ<<8)+act2	; $0601 (bad ending, not all emeralds)
 
 ; Colours
 cBlack:		equ $000		; colour black

--- a/_inc/DynamicLevelEvents.asm
+++ b/_inc/DynamicLevelEvents.asm
@@ -237,7 +237,7 @@ DLE_SBZ3:
 		bhs.s	locret_6F8C	; if not, branch
 		clr.b	(v_lastlamp).w
 		move.w	#1,(f_restart).w ; restart level
-		move.w	#(id_SBZ<<8)+2,(v_zone).w ; set level number to 0502 (FZ)
+		move.w	#id_FZ,(v_zone).w ; set level number to 0502 (FZ)
 		move.b	#1,(f_playerctrl).w ; lock controls
 
 locret_6F8C:

--- a/_inc/LZWaterFeatures.asm
+++ b/_inc/LZWaterFeatures.asm
@@ -332,7 +332,7 @@ LZWindTunnels:
 		cmp.w	(a2),d0
 		bhs.s	.movesonic
 		moveq	#2,d0
-		cmpi.b	#1,(v_act).w	; is act number 2?
+		cmpi.b	#act2,(v_act).w	; is act number 2?
 		bne.s	.notact2	; if not, branch
 		neg.w	d0
 

--- a/_inc/Level Drawing (JP1).asm
+++ b/_inc/Level Drawing (JP1).asm
@@ -681,7 +681,7 @@ LoadTilesFromStart:
 		beq.w	Draw_GHz_Bg
 		cmpi.b	#id_MZ,(v_zone).w
 		beq.w	Draw_Mz_Bg
-		cmpi.w	#(id_SBZ<<8)+0,(v_zone).w
+		cmpi.w	#id_SBZ_act1,(v_zone).w
 		beq.w	Draw_SBz_Bg
 		cmpi.b	#id_EndZ,(v_zone).w
 		beq.w	Draw_GHz_Bg

--- a/_inc/LevelOrder.asm
+++ b/_inc/LevelOrder.asm
@@ -4,40 +4,43 @@
 ; ---------------------------------------------------------------------------
 
 		; Green Hill Zone
-		dc.b id_GHZ, 1	; Act 1
-		dc.b id_GHZ, 2	; Act 2
-		dc.b id_MZ, 0	; Act 3
-		dc.b 0, 0
+		dc.w id_GHZ_act2	; Act 1
+		dc.w id_GHZ_act3	; Act 2
+		dc.w id_MZ_act1		; Act 3
+		dc.w 0			; Act 4 (unused)
 
 		; Labyrinth Zone
-		dc.b id_LZ, 1	; Act 1
-		dc.b id_LZ, 2	; Act 2
-		dc.b id_SLZ, 0	; Act 3
-		dc.b id_SBZ, 2	; Scrap Brain Zone Act 3
+		dc.w id_LZ_act2		; Act 1
+		dc.w id_LZ_act3		; Act 2
+		dc.w id_SLZ_act1	; Act 3
+		dc.w id_FZ		; Act 4 (Scrap Brain Zone Act 3)
 
 		; Marble Zone
-		dc.b id_MZ, 1	; Act 1
-		dc.b id_MZ, 2	; Act 2
-		dc.b id_SYZ, 0	; Act 3
-		dc.b 0, 0
+		dc.w id_MZ_act2		; Act 1
+		dc.w id_MZ_act3		; Act 2
+		dc.w id_SYZ_act1	; Act 3
+		dc.w 0			; Act 4 (unused)
 
 		; Star Light Zone
-		dc.b id_SLZ, 1	; Act 1
-		dc.b id_SLZ, 2	; Act 2
-		dc.b id_SBZ, 0	; Act 3
-		dc.b 0, 0
+		dc.w id_SLZ_act2	; Act 1
+		dc.w id_SLZ_act3	; Act 2
+		dc.w id_SBZ_act1	; Act 3
+		dc.w 0			; Act 4 (unused)
 
 		; Spring Yard Zone
-		dc.b id_SYZ, 1	; Act 1
-		dc.b id_SYZ, 2	; Act 2
-		dc.b id_LZ, 0	; Act 3
-		dc.b 0, 0
+		dc.w id_SYZ_act2	; Act 1
+		dc.w id_SYZ_act3	; Act 2
+		dc.w id_LZ_act1		; Act 3
+		dc.w 0			; Act 4 (unused)
 
 		; Scrap Brain Zone
-		dc.b id_SBZ, 1	; Act 1
-		dc.b id_LZ, 3	; Act 2
-		dc.b 0, 0	; Final Zone
-		dc.b 0, 0
-		even
+		dc.w id_SBZ_act2	; Act 1
+		dc.w id_LZ_act4		; Act 2
+		dc.w 0			; Act 3 (Final Zone)
+		dc.w 0			; Act 4 (unused)
+
+; Note: Even though this array properly defines the level order for SBZ2/SBZ3/FZ,
+; those transitions are not handled here, as they were hardcoded elsewhere.
 
 		zonewarning LevelOrder,8
+		even

--- a/_inc/PaletteCycle.asm
+++ b/_inc/PaletteCycle.asm
@@ -71,7 +71,7 @@ PalCycle_LZ:
 		andi.w	#3,d0		; if cycle > 3, reset to 0
 		lsl.w	#3,d0
 		lea	(Pal_LZCyc1).l,a0
-		cmpi.b	#3,(v_act).w	; check if level is SBZ3
+		cmpi.b	#act4,(v_act).w	; check if on act 4 (SBZ3)
 		bne.s	PCycLZ_NotSBZ3
 		lea	(Pal_SBZ3Cyc).l,a0 ; load SBZ3 palette instead
 

--- a/_incObj/01 Sonic.asm
+++ b/_incObj/01 Sonic.asm
@@ -137,7 +137,7 @@ Sonic_Display:
 		blo.s	.removeinvincible
 		moveq	#0,d0
 		move.b	(v_zone).w,d0
-		cmpi.w	#(id_LZ<<8)+3,(v_zone).w ; check if level is SBZ3
+		cmpi.w	#id_LZ_act4,(v_zone).w ; check if level is SBZ3 (LZ4)
 		bne.s	.music
 		moveq	#5,d0		; play SBZ music
 
@@ -860,13 +860,13 @@ Sonic_LevelBound:
 
 ; Boundary_Bottom
 .bottom:
-		cmpi.w	#(id_SBZ<<8)+1,(v_zone).w ; is level SBZ2 ?
+		cmpi.w	#id_SBZ_act2,(v_zone).w ; is level SBZ2?
 		bne.w	KillSonic	; if not, kill Sonic
 		cmpi.w	#$2000,(v_player+obX).w
 		blo.w	KillSonic
 		clr.b	(v_lastlamp).w	; clear lamppost counter
 		move.w	#1,(f_restart).w ; restart the level
-		move.w	#(id_LZ<<8)+3,(v_zone).w ; set level to SBZ3 (LZ4)
+		move.w	#id_LZ_act4,(v_zone).w ; set level to SBZ3 (LZ4)
 		rts
 ; ===========================================================================
 

--- a/_incObj/33 Pushable Blocks.asm
+++ b/_incObj/33 Pushable Blocks.asm
@@ -61,7 +61,7 @@ loc_BF6E:	; Routine 2
 		move.w	#$11,d3
 		move.w	obX(a0),d4
 		bsr.w	loc_C186
-		cmpi.w	#(id_MZ<<8)+0,(v_zone).w ; is the level MZ act 1?
+		cmpi.w	#id_MZ_act1,(v_zone).w ; is the level MZ act 1?
 		bne.s	loc_BFC6	; if not, branch
 		bclr	#7,obSubtype(a0)
 		move.w	obX(a0),d0
@@ -194,7 +194,7 @@ loc_C104:
 ; ===========================================================================
 
 PushB_ChkLava:
-		cmpi.w	#(id_MZ<<8)+1,(v_zone).w ; is the level MZ act 2?
+		cmpi.w	#id_MZ_act2,(v_zone).w ; is the level MZ act 2?
 		bne.s	PushB_ChkLava2	; if not, branch
 		move.w	#-$20,d2
 		cmpi.w	#$DD0,obX(a0)
@@ -207,7 +207,7 @@ PushB_ChkLava:
 ; ===========================================================================
 
 PushB_ChkLava2:
-		cmpi.w	#(id_MZ<<8)+2,(v_zone).w ; is the level MZ act 3?
+		cmpi.w	#id_MZ_act3,(v_zone).w ; is the level MZ act 3?
 		bne.s	PushB_NoLava	; if not, branch
 		move.w	#$20,d2
 		cmpi.w	#$560,obX(a0)

--- a/_incObj/34 Title Cards.asm
+++ b/_incObj/34 Title Cards.asm
@@ -21,13 +21,13 @@ Card_CheckSBZ3:	; Routine 0
 		movea.l	a0,a1
 		moveq	#0,d0
 		move.b	(v_zone).w,d0
-		cmpi.w	#(id_LZ<<8)+3,(v_zone).w ; check if level is SBZ 3
+		cmpi.w	#id_LZ_act4,(v_zone).w ; check if level is SBZ3 (LZ4)
 		bne.s	Card_CheckFZ
 		moveq	#5,d0		; load title card number 5 (SBZ)
 
 Card_CheckFZ:
 		move.w	d0,d2
-		cmpi.w	#(id_SBZ<<8)+2,(v_zone).w ; check if level is FZ
+		cmpi.w	#id_FZ,(v_zone).w ; check if level is FZ
 		bne.s	Card_LoadConfig
 		moveq	#6,d0		; load title card number 6 (FZ)
 		moveq	#$B,d2		; use "FINAL" mappings
@@ -51,12 +51,12 @@ Card_Loop:
 		move.b	d2,d0
 
 Card_ActNumber:
-		cmpi.b	#7,d0
-		bne.s	Card_MakeSprite
-		add.b	(v_act).w,d0
-		cmpi.b	#3,(v_act).w
-		bne.s	Card_MakeSprite
-		subq.b	#1,d0
+		cmpi.b	#7,d0		; is this the act number object?
+		bne.s	Card_MakeSprite	; if not, branch
+		add.b	(v_act).w,d0	; use appropriate act number art for current act
+		cmpi.b	#act4,(v_act).w	; check if on act 4 (for SBZ3/LZ4)
+		bne.s	Card_MakeSprite	; if not, branch
+		subq.b	#1,d0		; keep using "3" art for act number
 
 Card_MakeSprite:
 		move.b	d0,obFrame(a1)	; display frame number d0

--- a/_incObj/3A Got Through Card.asm
+++ b/_incObj/3A Got Through Card.asm
@@ -119,9 +119,9 @@ Got_ChkBonus:
 		move.w	#sfx_Cash,d0
 		jsr	(QueueSound2).l	; play "ker-ching" sound
 		addq.b	#2,obRoutine(a0)
-		cmpi.w	#(id_SBZ<<8)+1,(v_zone).w
-		bne.s	Got_SetDelay
-		addq.b	#4,obRoutine(a0)
+		cmpi.w	#id_SBZ_act2,(v_zone).w	; is level SBZ2?
+		bne.s	Got_SetDelay		; if not, branch
+		addq.b	#4,obRoutine(a0)	; prepare SBZ3 transition cutscene
 
 Got_SetDelay:
 		move.w	#180,obTimeFrame(a0) ; set time delay to 3 seconds

--- a/_incObj/56 Floating Blocks and Doors.asm
+++ b/_incObj/56 Floating Blocks and Doors.asm
@@ -213,7 +213,7 @@ FBlock_Action:	; Routine 2
 ; moves up when a switch is pressed
 		tst.b	objoff_38(a0)
 		bne.s	.loc_104A4
-		cmpi.w	#(id_LZ<<8)+0,(v_zone).w ; is level LZ1 ?
+		cmpi.w	#id_LZ_act1,(v_zone).w ; is level LZ1 ?
 		bne.s	.aaa		; if not, branch
 		cmpi.b	#3,fb_type(a0)
 		bne.s	.aaa
@@ -229,7 +229,7 @@ FBlock_Action:	; Routine 2
 		move.b	fb_type(a0),d0
 		btst	#0,(a2,d0.w)
 		beq.s	.loc_104AE
-		cmpi.w	#(id_LZ<<8)+0,(v_zone).w ; is level LZ1 ?
+		cmpi.w	#id_LZ_act1,(v_zone).w ; is level LZ1 ?
 		bne.s	.loc_1049E	; if not, branch
 		cmpi.b	#3,d0
 		bne.s	.loc_1049E

--- a/_incObj/63 LZ Conveyor.asm
+++ b/_incObj/63 LZ Conveyor.asm
@@ -14,7 +14,7 @@ LCon_Display:
 ; ===========================================================================
 
 loc_1236A:
-		cmpi.b	#2,(v_act).w
+		cmpi.b	#act3,(v_act).w
 		bne.s	loc_12378
 		cmpi.w	#-$80,d0
 		bhs.s	LCon_Display

--- a/_incObj/6F SBZ Spin Platform Conveyor.asm
+++ b/_incObj/6F SBZ Spin Platform Conveyor.asm
@@ -14,7 +14,7 @@ SpinC_Display:
 ; ===========================================================================
 
 loc_1629A:
-		cmpi.b	#2,(v_act).w	; check if act is 3
+		cmpi.b	#act3,(v_act).w	; check if act is 3
 		bne.s	SpinC_Act1or2	; if not, branch
 		cmpi.w	#-$80,d0
 		bhs.s	SpinC_Display

--- a/sonic.asm
+++ b/sonic.asm
@@ -2267,7 +2267,7 @@ Tit_LoadText:
 		move.w	#0,(v_debuguse).w ; disable debug item placement mode
 		move.w	#0,(f_demo).w	; disable debug mode
 		move.w	#0,(v_unused2).w ; unused variable
-		move.w	#(id_GHZ<<8),(v_zone).w	; set level to GHZ (00)
+		move.w	#id_GHZ_act1,(v_zone).w	; set level to GHZ1 (000)
 		move.w	#0,(v_pcyc_time).w ; disable palette cycling
 		bsr.w	LevelSizeLoad
 		bsr.w	DeformLayers
@@ -2501,7 +2501,7 @@ LevSel_PlaySnd:
 
 LevSel_Ending:
 		move.b	#id_Ending,(v_gamemode).w ; set screen mode to $18 (Ending)
-		move.w	#(id_EndZ<<8),(v_zone).w  ; set level to 0600 (good Ending)
+		move.w	#id_EndZ_good,(v_zone).w  ; set level to 0600 (good Ending)
 		rts
 ; ===========================================================================
 
@@ -2563,50 +2563,50 @@ PlayLevel:
 LevSel_Ptrs:
 	if Revision=0
 		; old level order
-		dc.b id_GHZ, 0
-		dc.b id_GHZ, 1
-		dc.b id_GHZ, 2
-		dc.b id_LZ, 0
-		dc.b id_LZ, 1
-		dc.b id_LZ, 2
-		dc.b id_MZ, 0
-		dc.b id_MZ, 1
-		dc.b id_MZ, 2
-		dc.b id_SLZ, 0
-		dc.b id_SLZ, 1
-		dc.b id_SLZ, 2
-		dc.b id_SYZ, 0
-		dc.b id_SYZ, 1
-		dc.b id_SYZ, 2
-		dc.b id_SBZ, 0
-		dc.b id_SBZ, 1
-		dc.b id_LZ, 3		; Scrap Brain Zone 3
-		dc.b id_SBZ, 2		; Final Zone
-		dc.b id_SS, 0		; Special Stage
-		dc.b $80, 0		; Sound Test
+		dc.w id_GHZ_act1
+		dc.w id_GHZ_act2
+		dc.w id_GHZ_act3
+		dc.w id_LZ_act1
+		dc.w id_LZ_act2
+		dc.w id_LZ_act3
+		dc.w id_MZ_act1
+		dc.w id_MZ_act2
+		dc.w id_MZ_act3
+		dc.w id_SLZ_act1
+		dc.w id_SLZ_act2
+		dc.w id_SLZ_act3
+		dc.w id_SYZ_act1
+		dc.w id_SYZ_act2
+		dc.w id_SYZ_act3
+		dc.w id_SBZ_act1
+		dc.w id_SBZ_act2
+		dc.w id_LZ_act4		; Scrap Brain Zone 3
+		dc.w id_FZ		; Final Zone
+		dc.w id_SS<<8		; Special Stage (dummy value)
+		dc.w $8000		; Sound Test
 	else
 		; correct level order
-		dc.b id_GHZ, 0
-		dc.b id_GHZ, 1
-		dc.b id_GHZ, 2
-		dc.b id_MZ, 0
-		dc.b id_MZ, 1
-		dc.b id_MZ, 2
-		dc.b id_SYZ, 0
-		dc.b id_SYZ, 1
-		dc.b id_SYZ, 2
-		dc.b id_LZ, 0
-		dc.b id_LZ, 1
-		dc.b id_LZ, 2
-		dc.b id_SLZ, 0
-		dc.b id_SLZ, 1
-		dc.b id_SLZ, 2
-		dc.b id_SBZ, 0
-		dc.b id_SBZ, 1
-		dc.b id_LZ, 3		; Scrap Brain Zone 3
-		dc.b id_SBZ, 2		; Final Zone
-		dc.b id_SS, 0		; Special Stage
-		dc.b $80, 0		; Sound Test
+		dc.w id_GHZ_act1
+		dc.w id_GHZ_act2
+		dc.w id_GHZ_act3
+		dc.w id_MZ_act1
+		dc.w id_MZ_act2
+		dc.w id_MZ_act3
+		dc.w id_SYZ_act1
+		dc.w id_SYZ_act2
+		dc.w id_SYZ_act3
+		dc.w id_LZ_act1
+		dc.w id_LZ_act2
+		dc.w id_LZ_act3
+		dc.w id_SLZ_act1
+		dc.w id_SLZ_act2
+		dc.w id_SLZ_act3
+		dc.w id_SBZ_act1
+		dc.w id_SBZ_act2
+		dc.w id_LZ_act4		; Scrap Brain Zone 3
+		dc.w id_FZ		; Final Zone
+		dc.w id_SS<<8		; Special Stage (dummy value)
+		dc.w $8000		; Sound Test
 	endif
 LevSel_PtrsEnd:	even
 
@@ -3029,7 +3029,7 @@ Level_LoadPal:
 		bne.s	Level_GetBgm	; if not, branch
 
 		moveq	#palid_LZSonWater,d0 ; palette number $F (LZ)
-		cmpi.b	#3,(v_act).w	; is act number 3?
+		cmpi.b	#act4,(v_act).w	; check if on act 4 (for SBZ3/LZ4)?
 		bne.s	Level_WaterPal	; if not, branch
 		moveq	#palid_SBZ3SonWat,d0 ; palette number $10 (SBZ3)
 
@@ -3044,12 +3044,12 @@ Level_GetBgm:
 		bmi.s	Level_SkipTtlCard
 		moveq	#0,d0
 		move.b	(v_zone).w,d0
-		cmpi.w	#(id_LZ<<8)+3,(v_zone).w ; is level SBZ3?
+		cmpi.w	#id_LZ_act4,(v_zone).w ; is level SBZ3 (LZ4)?
 		bne.s	Level_BgmNotLZ4	; if not, branch
 		moveq	#5,d0		; use 5th music (SBZ)
 
 Level_BgmNotLZ4:
-		cmpi.w	#(id_SBZ<<8)+2,(v_zone).w ; is level FZ?
+		cmpi.w	#id_FZ,(v_zone).w ; is level FZ?
 		bne.s	Level_PlayBgm	; if not, branch
 		moveq	#6,d0		; use 6th music (FZ)
 
@@ -3158,7 +3158,7 @@ Level_ChkWaterPal:
 		cmpi.b	#id_LZ,(v_zone).w ; is level LZ/SBZ3?
 		bne.s	Level_Delay	; if not, branch
 		moveq	#palid_LZWater,d0 ; palette $B (LZ underwater)
-		cmpi.b	#3,(v_act).w	; is level SBZ3?
+		cmpi.b	#act4,(v_act).w	; check if on act 4 (for SBZ3/LZ4)
 		bne.s	Level_WtrNotSbz	; if not, branch
 		moveq	#palid_SBZ3Water,d0 ; palette $D (SBZ3 underwater)
 
@@ -3376,8 +3376,8 @@ SyncEnd:
 SignpostArtLoad:
 		tst.w	(v_debuguse).w	; is debug mode being used?
 		bne.w	.exit		; if yes, branch
-		cmpi.b	#2,(v_act).w	; is act number 02 (act 3)?
-		beq.s	.exit		; if yes, branch
+		cmpi.b	#act3,(v_act).w	; is this a third act?
+		beq.s	.exit		; if yes, don't load art (due to the boss fight)
 
 		move.w	(v_screenposx).w,d0
 		move.w	(v_limitright2).w,d1
@@ -3494,9 +3494,9 @@ SS_ChkEnd:
 		bne.w	SS_ToLevel
 	endif
 		move.b	#id_Level,(v_gamemode).w ; set screen mode to $0C (level)
-		cmpi.w	#(id_SBZ<<8)+3,(v_zone).w ; is level number higher than FZ?
+		cmpi.w	#id_FZ+1,(v_zone).w ; is level number higher than FZ (0502)?
 		blo.s	SS_Finish	; if not, branch
-		clr.w	(v_zone).w	; set to GHZ1
+		clr.w	(v_zone).w	; set to GHZ1 (possibly as a failsafe)
 
 SS_Finish:
 		move.w	#60,(v_generictimer).w ; set delay time to 1 second
@@ -4045,10 +4045,10 @@ GM_Ending:
 		move.w	#$8A00+223,(v_hbla_hreg).w ; set palette change position (for water)
 		move.w	(v_hbla_hreg).w,(a6)
 		move.w	#30,(v_air).w
-		move.w	#id_EndZ<<8,(v_zone).w ; set level number to 0600 (extra flowers)
+		move.w	#id_EndZ_good,(v_zone).w ; set level number to 0600 (extra flowers)
 		cmpi.b	#6,(v_emeralds).w ; do you have all 6 emeralds?
 		beq.s	End_LoadData	; if yes, branch
-		move.w	#(id_EndZ<<8)+1,(v_zone).w ; set level number to 0601 (no flowers)
+		move.w	#id_EndZ_bad,(v_zone).w ; set level number to 0601 (no flowers)
 
 End_LoadData:
 		moveq	#plcid_Ending,d0
@@ -4469,14 +4469,14 @@ LevelDataLoad:
 		move.w	(a2)+,d0
 		move.w	(a2),d0
 		andi.w	#$FF,d0
-		cmpi.w	#(id_LZ<<8)+3,(v_zone).w ; is level SBZ3 (LZ4) ?
+		cmpi.w	#id_LZ_act4,(v_zone).w ; is level SBZ3 (LZ4)?
 		bne.s	.notSBZ3	; if not, branch
 		moveq	#palid_SBZ3,d0	; use SB3 palette
 
 .notSBZ3:
-		cmpi.w	#(id_SBZ<<8)+1,(v_zone).w ; is level SBZ2?
+		cmpi.w	#id_SBZ_act2,(v_zone).w ; is level SBZ2?
 		beq.s	.isSBZorFZ	; if yes, branch
-		cmpi.w	#(id_SBZ<<8)+2,(v_zone).w ; is level FZ?
+		cmpi.w	#id_FZ,(v_zone).w ; is level FZ?
 		bne.s	.normalpal	; if not, branch
 
 .isSBZorFZ:
@@ -6239,7 +6239,7 @@ ResumeMusic:
 		cmpi.w	#12,(v_air).w	; more than 12 seconds of air left?
 		bhi.s	.over12		; if yes, branch
 		move.w	#bgm_LZ,d0	; play LZ music
-		cmpi.w	#(id_LZ<<8)+3,(v_zone).w ; check if level is 0103 (SBZ3)
+		cmpi.w	#id_LZ_act4,(v_zone).w ; check if level is SBZ3 (LZ4)
 		bne.s	.notsbz
 		move.w	#bgm_SBZ,d0	; play SBZ music
 


### PR DESCRIPTION
All other disassemblies have these, and `id_GHZ_act2` is much easier to read than `(id_GHZ<<8)+1`