### PR TITLE
Update v_emldlist description in variables.asm

### DIFF
--- a/Variables.asm
+++ b/Variables.asm
@@ -383,7 +383,7 @@ v_lamp_wtrstat:		ds.b	1		; water state at lamppost
 v_lamp_lives:		ds.b	1		; lives counter at lamppost
 			ds.b	2		; unused
 v_emeralds:		ds.b	1		; number of chaos emeralds
-v_emldlist:		ds.b	6		; which individual emeralds you have (00 = no; 01 = yes)
+v_emldlist:		ds.b	6		; special stage where each emerald was obtained
 v_oscillate:		ds.w	1		; oscillation bitfield
 v_timingandscreenvariables:
 v_timingvariables:


### PR DESCRIPTION
I've been reading the Special Stage code and found that the description of `v_emldlist` found in `Variables.asm` doesn't match its usage. This is the code that decides which Special Stage to load, in `sonic.asm` (copypasted as-is, no comments are mine):

```
SS_Load:
		moveq	#0,d0
		move.b	(v_lastspecial).w,d0 ; load number of last special stage entered
		addq.b	#1,(v_lastspecial).w
		cmpi.b	#6,(v_lastspecial).w
		blo.s	SS_ChkEmldNum
		move.b	#0,(v_lastspecial).w ; reset if higher than 6

SS_ChkEmldNum:
		cmpi.b	#6,(v_emeralds).w ; do you have all emeralds?
		beq.s	SS_LoadData	; if yes, branch
		moveq	#0,d1
		move.b	(v_emeralds).w,d1
		subq.b	#1,d1
		blo.s	SS_LoadData
		lea	(v_emldlist).w,a3 ; check which emeralds you have

SS_ChkEmldLoop:	
		cmp.b	(a3,d1.w),d0
		bne.s	SS_ChkEmldRepeat
		bra.s	SS_Load
; ===========================================================================

SS_ChkEmldRepeat:
		dbf	d1,SS_ChkEmldLoop

SS_LoadData:
        ; Special Stage ID in d0 is loaded.
```

It's first loading the next special stage ID updated from last time (on a separate note, I find `v_lastspecial` and the `; load number of last special stage entered` comment misleading too because it's not the last special stage **entered**, it's the special stage that is **next** to the last one entered, but um yeah that may be a separate topic). Then it checks amount of emeralds. If it's 0, that means we have no emeralds so we can just play the next special stage, no extra checks required (our array is supposed to be empty anyways). If we have at least one emerald, we need to check if the current special stage is available to play. We iterate over the `v_emldlist` array backwards (i.e. from the end until the start) and perform a linear search: if there is any ID in the array that matches the current special stage, skip over that one and search for the next one. Keep repeating until you find a special stage that hasn't been completed yet. In this sense, **both 00 and 01 are valid values in the array**.

I would say the comment 'check which emeralds you have' also needs updating, but at the very least I think the description in Variables.asm is the most misleading. I could update that as well in this PR though.

Also, this would have to be updated in the asm68k branch as well.