### PR TITLE
Fix SonLVL Ring.cs compilation issue on Mono

### DIFF
--- a/Utility Project Files/SonLVL INI Files/Common/Ring.cs
+++ b/Utility Project Files/SonLVL INI Files/Common/Ring.cs
@@ -33,7 +33,9 @@ namespace S1ObjectDefinitions.Common
 		public override void Init(ObjectData data)
 		{
 			byte[] artfile = ObjectHelper.OpenArtFile("../../artnem/Rings.nem", CompressionType.Nemesis);
-			img = ObjectHelper.MapASMToBmp(artfile, data.CustomProperties.GetValueOrDefault("revision", "0") == "1" ? "../../_maps/Rings (REV01).asm" : "../../_maps/Rings (REV00).asm", 0, 1);
+			
+			string rev = "0";
+			img = ObjectHelper.MapASMToBmp(artfile, (data.CustomProperties.TryGetValue("revision", out rev) && rev == "1") ? "../../_maps/Rings (REV01).asm" : "../../_maps/Rings (REV00).asm", 0, 1);
 		}
 
 		public override ReadOnlyCollection<byte> Subtypes


### PR DESCRIPTION
When running SonLVL through Mono on Linux, the Ring object definition would fail to compile, reporting that the `GetValueOrDefault` call is vague between the `Collections.Generic` namespace and SonLVL's own version of the function, despite the code compiling and running fine on Windows. This PR adjusts the object definition to substitute that function call, so that it can work correctly on both platforms again.