### PR TITLE
Documented "unknown" REV00 scrolling routines

### DIFF
--- a/_inc/Level Drawing (REV00).asm
+++ b/_inc/Level Drawing (REV00).asm
@@ -223,6 +223,8 @@ locret_6A80:
 
 ; Abandoned unused scroll block code.
 ; This would have drawn a scroll block that started at 208 pixels down, and was 48 pixels long.
+; See Calc_VRAM_Pos_Unknown for more information.
+DrawBGScrollBlock_PlaneZ:
 		tst.b	(a2)
 		beq.s	locret_6AD6
 		bclr	#2,(a2)
@@ -234,7 +236,7 @@ locret_6A80:
 		sub.w	d1,d4
 		move.w	d4,-(sp)
 		moveq	#-16,d5
-		bsr.w	Calc_VRAM_Pos_Unknown
+		bsr.w	Calc_VRAM_Pos_PlaneZ
 		move.w	(sp)+,d4
 		moveq	#-16,d5
 		moveq	#3-1,d6	; Draw only three rows
@@ -250,7 +252,7 @@ loc_6AAC:
 		sub.w	d1,d4
 		move.w	d4,-(sp)
 		move.w	#320,d5
-		bsr.w	Calc_VRAM_Pos_Unknown
+		bsr.w	Calc_VRAM_Pos_PlaneZ
 		move.w	(sp)+,d4
 		move.w	#320,d5
 		moveq	#3-1,d6
@@ -480,13 +482,16 @@ Calc_VRAM_Pos:
 ; ===========================================================================
 
 ; not used
-; This is just like Calc_VRAM_Pos, but seemingly for an earlier
-; VRAM layout: the only difference is the high bits of the
-; plane's VRAM address, which are 10 instead of 11.
-; Both the foreground and background are at $C000 and $E000
-; respectively, so this one starting at $8000 makes no sense.
-; sub_6C3C:
-Calc_VRAM_Pos_Unknown:
+; What this does is swap the background nametable with the window layer in order
+; to create a third scrolling layer that appears above the foreground. However,
+; this comes at the cost of the background becoming garbled at the bottom of the
+; screen, which was likely what contributed in its removal. Internally, it was
+; known as "Plane Z", and was also the intended use of the third layout entry.
+; Presumably, this (alongside bit 3 of obRender) was what was used to achieve the
+; foreground effect seen in the Tokyo Toy Show '90. Ultimately, Sonic 2 repurposed
+; this code to draw player 2's foreground in multiplayer.
+; sub_6C3C: Calc_VRAM_Pos_Unknown:
+Calc_VRAM_Pos_PlaneZ:
 		add.w	4(a3),d4
 		add.w	(a3),d5
 		andi.w	#$F0,d4
@@ -498,7 +503,7 @@ Calc_VRAM_Pos_Unknown:
 		swap	d0
 		move.w	d4,d0
 		rts
-; End of function Calc_VRAM_Pos_Unknown
+; End of function Calc_VRAM_Pos_PlaneZ
 
 ; ===========================================================================
 ; ---------------------------------------------------------------------------


### PR DESCRIPTION
I documented this for _Sonic 2_ nearly a year ago, may as well now document it here.

The unused REV00 scrolling effects work by swapping the background with the window layer at line 208, which creates a third scrolling layer that overlaps the foreground, at the cost of the background appearing garbled at the bottom. Katsushimi has a video of it below in the prototype, as well as a link to Devon's post on it. Symbol tables call it **Plane Z**. This works hand-in-hand with a feature of the sprite renderer that can position sprites based on background camera positions, and was likely how Sonic Team achieved the scrolling effect in Tokyo Toy Show '90.

I can imagine that both the garbled background and sprite limit concerns were what constituted its removal. Curiously, however, the second function would ultimately be repurposed for Tails' foreground in _Sonic 2_'s multiplayer.

www.youtube.com/watch?v=XSRasP1S7tI