### PR TITLE
Introduced offset table macros

### DIFF
--- a/Macros.asm
+++ b/Macros.asm
@@ -170,6 +170,30 @@ enable_display:	macro
 		endm
 
 ; ---------------------------------------------------------------------------
+; offset table macros (taken from the Sonic 2 disassembly)
+; ---------------------------------------------------------------------------
+
+; macro to declare the base offset for the current offset table
+offsetTable:	macro {INTLABEL}
+current_offset_table := __LABEL__
+__LABEL__ label *
+	endm
+
+; macro to declare an entry in an offset table
+offsetTableEntry:	macro pointer
+	dc.ATTRIBUTE pointer-current_offset_table
+	endm
+
+; shorthand for offsetTableEntry.w with variable arguments support
+ptr:	macro pointers
+	if "pointers"<>""
+		offsetTableEntry.w pointers
+		shift
+		ptr ALLARGS
+	endif
+	endm
+
+; ---------------------------------------------------------------------------
 ; long conditional jumps
 ; ---------------------------------------------------------------------------
 

--- a/_anim/Ball Hog.asm
+++ b/_anim/Ball Hog.asm
@@ -2,7 +2,8 @@
 ; Animation script - Ball Hog enemy (SBZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Hog:	dc.w .hog-Ani_Hog
+Ani_Hog:	offsetTable
+		ptr .hog
 
 .hog:		dc.b 9
 		dc.b 0, 0, 2, 2, 3, 2

--- a/_anim/Basaran.asm
+++ b/_anim/Basaran.asm
@@ -2,9 +2,10 @@
 ; Animation script - Basaran enemy (MZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Bas:	dc.w .still-Ani_Bas
-		dc.w .fall-Ani_Bas
-		dc.w .fly-Ani_Bas
+Ani_Bas:	offsetTable
+		ptr .still
+		ptr .fall
+		ptr .fly
 
 .still:		dc.b 15
 		dc.b 0

--- a/_anim/Bomb Enemy.asm
+++ b/_anim/Bomb Enemy.asm
@@ -2,11 +2,12 @@
 ; Animation script - Bomb enemy (SLZ/SBZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Bomb:	dc.w .stand-Ani_Bomb
-		dc.w .walk-Ani_Bomb
-		dc.w .activated-Ani_Bomb
-		dc.w .fuse-Ani_Bomb
-		dc.w .shrapnel-Ani_Bomb
+Ani_Bomb:	offsetTable
+		ptr .stand
+		ptr .walk
+		ptr .activated
+		ptr .fuse
+		ptr .shrapnel
 
 .stand:		dc.b 19
 		dc.b 1, 0

--- a/_anim/Bubbles.asm
+++ b/_anim/Bubbles.asm
@@ -2,13 +2,14 @@
 ; Animation script - Bubbles (LZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Bub:	dc.w .small-Ani_Bub
-		dc.w .medium-Ani_Bub
-		dc.w .large-Ani_Bub
-		dc.w .incroutine-Ani_Bub
-		dc.w .incroutine-Ani_Bub
-		dc.w .burst-Ani_Bub
-		dc.w .bubmaker-Ani_Bub
+Ani_Bub:	offsetTable
+		ptr .small
+		ptr .medium
+		ptr .large
+		ptr .incroutine
+		ptr .incroutine
+		ptr .burst
+		ptr .bubmaker
 
 .small:		dc.b 14
 		dc.b 0, 1, 2

--- a/_anim/Bumper.asm
+++ b/_anim/Bumper.asm
@@ -2,8 +2,9 @@
 ; Animation script - Bumper (SYZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Bump:	dc.w .idle-Ani_Bump
-		dc.w .touched-Ani_Bump
+Ani_Bump:	offsetTable
+		ptr .idle
+		ptr .touched
 
 .idle:		dc.b 15
 		dc.b 0

--- a/_anim/Burning Grass.asm
+++ b/_anim/Burning Grass.asm
@@ -2,7 +2,8 @@
 ; Animation script - burning grass that sits on the floor (MZ)
 ; ---------------------------------------------------------------------------
 
-Ani_GFire:	dc.w .burn-Ani_GFire
+Ani_GFire:	offsetTable
+		ptr .burn
 
 .burn:		dc.b 5
 		dc.b 0, 0|aniXFlip, 1, 1|aniXFlip

--- a/_anim/Burrobot.asm
+++ b/_anim/Burrobot.asm
@@ -2,10 +2,11 @@
 ; Animation script - Burrobot enemy (LZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Burro:	dc.w .walk1-Ani_Burro
-		dc.w .walk2-Ani_Burro
-		dc.w .digging-Ani_Burro
-		dc.w .fall-Ani_Burro
+Ani_Burro:	offsetTable
+		ptr .walk1
+		ptr .walk2
+		ptr .digging
+		ptr .fall
 
 .walk1:		dc.b 3
 		dc.b 0, 6

--- a/_anim/Buzz Bomber Missile.asm
+++ b/_anim/Buzz Bomber Missile.asm
@@ -2,8 +2,9 @@
 ; Animation script - missile that Buzz Bomber enemy throws (GHZ/MZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Missile:	dc.w .flare-Ani_Missile
-		dc.w .missile-Ani_Missile
+Ani_Missile:	offsetTable
+		ptr .flare
+		ptr .missile
 
 .flare:		dc.b 7
 		dc.b 0, 1

--- a/_anim/Buzz Bomber.asm
+++ b/_anim/Buzz Bomber.asm
@@ -2,9 +2,10 @@
 ; Animation script - Buzz Bomber enemy (GHZ/MZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Buzz:	dc.w .fly1-Ani_Buzz
-		dc.w .fly2-Ani_Buzz
-		dc.w .fires-Ani_Buzz
+Ani_Buzz:	offsetTable
+		ptr .fly1
+		ptr .fly2
+		ptr .fires
 
 .fly1:		dc.b 1
 		dc.b 0, 1

--- a/_anim/Chopper.asm
+++ b/_anim/Chopper.asm
@@ -2,9 +2,10 @@
 ; Animation script - Chopper enemy (GHZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Chop:	dc.w .slow-Ani_Chop
-		dc.w .fast-Ani_Chop
-		dc.w .still-Ani_Chop
+Ani_Chop:	offsetTable
+		ptr .slow
+		ptr .fast
+		ptr .still
 
 .slow:		dc.b 7
 		dc.b 0, 1

--- a/_anim/Continue Screen Sonic.asm
+++ b/_anim/Continue Screen Sonic.asm
@@ -2,7 +2,8 @@
 ; Animation script - Sonic on the continue screen
 ; ---------------------------------------------------------------------------
 
-Ani_CSon:	dc.w .onfloor-Ani_CSon
+Ani_CSon:	offsetTable
+		ptr .onfloor
 
 .onfloor:	dc.b 4
 		dc.b 1, 1, 1, 1, 2, 2, 2, 3, 3

--- a/_anim/Crabmeat.asm
+++ b/_anim/Crabmeat.asm
@@ -2,14 +2,15 @@
 ; Animation script - Crabmeat enemy
 ; ---------------------------------------------------------------------------
 
-Ani_Crab:	dc.w .stand-Ani_Crab
-		dc.w .standslope-Ani_Crab
-		dc.w .standsloperev-Ani_Crab
-		dc.w .walk-Ani_Crab
-		dc.w .walkslope-Ani_Crab
-		dc.w .walksloperev-Ani_Crab
-		dc.w .firing-Ani_Crab
-		dc.w .ball-Ani_Crab
+Ani_Crab:	offsetTable
+		ptr .stand
+		ptr .standslope
+		ptr .standsloperev
+		ptr .walk
+		ptr .walkslope
+		ptr .walksloperev
+		ptr .firing
+		ptr .ball
 
 .stand:		dc.b 15
 		dc.b 0

--- a/_anim/Drowning Countdown.asm
+++ b/_anim/Drowning Countdown.asm
@@ -2,21 +2,22 @@
 ; Animation script - countdown numbers and bubbles (LZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Drown:	dc.w .zeroappear-Ani_Drown
-		dc.w .oneappear-Ani_Drown
-		dc.w .twoappear-Ani_Drown
-		dc.w .threeappear-Ani_Drown
-		dc.w .fourappear-Ani_Drown
-		dc.w .fiveappear-Ani_Drown
-		dc.w .smallbubble-Ani_Drown
-		dc.w .zeroflash-Ani_Drown
-		dc.w .oneflash-Ani_Drown
-		dc.w .twoflash-Ani_Drown
-		dc.w .threeflash-Ani_Drown
-		dc.w .fourflash-Ani_Drown
-		dc.w .fiveflash-Ani_Drown
-		dc.w .blank-Ani_Drown
-		dc.w .mediumbubble-Ani_Drown
+Ani_Drown:	offsetTable
+		ptr .zeroappear
+		ptr .oneappear
+		ptr .twoappear
+		ptr .threeappear
+		ptr .fourappear
+		ptr .fiveappear
+		ptr .smallbubble
+		ptr .zeroflash
+		ptr .oneflash
+		ptr .twoflash
+		ptr .threeflash
+		ptr .fourflash
+		ptr .fiveflash
+		ptr .blank
+		ptr .mediumbubble
 
 .zeroappear:	dc.b 5
 		dc.b 0, 1, 2, 3, 4, 9, $D

--- a/_anim/Eggman - Scrap Brain 2 & Final.asm
+++ b/_anim/Eggman - Scrap Brain 2 & Final.asm
@@ -2,13 +2,14 @@
 ; Animation script - Eggman (SBZ2 cutscene)
 ; ---------------------------------------------------------------------------
 
-Ani_SEgg:	dc.w .stand-Ani_SEgg
-		dc.w .laugh-Ani_SEgg
-		dc.w .jump1-Ani_SEgg
-		dc.w .intube-Ani_SEgg
-		dc.w .running-Ani_SEgg
-		dc.w .jump2-Ani_SEgg
-		dc.w .starjump-Ani_SEgg
+Ani_SEgg:	offsetTable
+		ptr .stand
+		ptr .laugh
+		ptr .jump1
+		ptr .intube
+		ptr .running
+		ptr .jump2
+		ptr .starjump
 
 .stand:		dc.b 126
 		dc.b 0

--- a/_anim/Eggman.asm
+++ b/_anim/Eggman.asm
@@ -2,18 +2,19 @@
 ; Animation script - Eggman (bosses)
 ; ---------------------------------------------------------------------------
 
-Ani_Eggman:	dc.w .ship-Ani_Eggman
-		dc.w .facenormal1-Ani_Eggman
-		dc.w .facenormal2-Ani_Eggman
-		dc.w .facenormal3-Ani_Eggman
-		dc.w .facelaugh-Ani_Eggman
-		dc.w .facehit-Ani_Eggman
-		dc.w .facepanic-Ani_Eggman
-		dc.w .blank-Ani_Eggman
-		dc.w .flame1-Ani_Eggman
-		dc.w .flame2-Ani_Eggman
-		dc.w .facedefeat-Ani_Eggman
-		dc.w .escapeflame-Ani_Eggman
+Ani_Eggman:	offsetTable
+		ptr .ship
+		ptr .facenormal1
+		ptr .facenormal2
+		ptr .facenormal3
+		ptr .facelaugh
+		ptr .facehit
+		ptr .facepanic
+		ptr .blank
+		ptr .flame1
+		ptr .flame2
+		ptr .facedefeat
+		ptr .escapeflame
 
 .ship:		dc.b 15
 		dc.b 0

--- a/_anim/Electrocuter.asm
+++ b/_anim/Electrocuter.asm
@@ -2,8 +2,9 @@
 ; Animation script - electrocution orbs (SBZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Elec:	dc.w .idle-Ani_Elec
-		dc.w .discharge-Ani_Elec
+Ani_Elec:	offsetTable
+		ptr .idle
+		ptr .discharge
 
 .idle:		dc.b 7
 		dc.b 0

--- a/_anim/Ending Sequence Sonic.asm
+++ b/_anim/Ending Sequence Sonic.asm
@@ -2,9 +2,10 @@
 ; Animation script - Sonic on the ending sequence
 ; ---------------------------------------------------------------------------
 
-Ani_ESon:	dc.w .hold-Ani_ESon
-		dc.w .confused-Ani_ESon
-		dc.w .leap-Ani_ESon
+Ani_ESon:	offsetTable
+		ptr .hold
+		ptr .confused
+		ptr .leap
 
 .hold:		dc.b 3
 		dc.b 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 2

--- a/_anim/FZ Eggman in Ship.asm
+++ b/_anim/FZ Eggman in Ship.asm
@@ -2,7 +2,8 @@
 ; Animation script - Eggman while escaping after landing final hit (FZ)
 ; ---------------------------------------------------------------------------
 
-Ani_FZEgg:	dc.w .exploding-Ani_FZEgg
+Ani_FZEgg:	offsetTable
+		ptr .exploding
 
 .exploding:	dc.b 3
 		dc.b 0, 1

--- a/_anim/Fireballs.asm
+++ b/_anim/Fireballs.asm
@@ -2,10 +2,11 @@
 ; Animation script - lava balls
 ; ---------------------------------------------------------------------------
 
-Ani_Fire:	dc.w .vertical-Ani_Fire
-		dc.w .vertcollide-Ani_Fire
-		dc.w .horizontal-Ani_Fire
-		dc.w .horicollide-Ani_Fire
+Ani_Fire:	offsetTable
+		ptr .vertical
+		ptr .vertcollide
+		ptr .horizontal
+		ptr .horicollide
 
 .vertical:	dc.b 5
 		dc.b 0, 0|aniXFlip, 1, 1|aniXFlip

--- a/_anim/Flamethrower.asm
+++ b/_anim/Flamethrower.asm
@@ -2,10 +2,11 @@
 ; Animation script - flamethrower (SBZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Flame:	dc.w .pipe1-Ani_Flame
-		dc.w .pipe2-Ani_Flame
-		dc.w .valve1-Ani_Flame
-		dc.w .valve2-Ani_Flame
+Ani_Flame:	offsetTable
+		ptr .pipe1
+		ptr .pipe2
+		ptr .valve1
+		ptr .valve2
 
 .pipe1:		dc.b 3
 		dc.b 0, 1, 2, 3, 4, 5, 6, 7, 8

--- a/_anim/Flapping Door.asm
+++ b/_anim/Flapping Door.asm
@@ -2,8 +2,9 @@
 ; Animation script - flapping door (LZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Flap:	dc.w .opening-Ani_Flap
-		dc.w .closing-Ani_Flap
+Ani_Flap:	offsetTable
+		ptr .opening
+		ptr .closing
 
 .opening:	dc.b 3
 		dc.b 0, 1

--- a/_anim/Harpoon.asm
+++ b/_anim/Harpoon.asm
@@ -2,10 +2,11 @@
 ; Animation script - harpoon (LZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Harp:	dc.w .h_extending-Ani_Harp
-		dc.w .h_retracting-Ani_Harp
-		dc.w .v_extending-Ani_Harp
-		dc.w .v_retracting-Ani_Harp
+Ani_Harp:	offsetTable
+		ptr .h_extending
+		ptr .h_retracting
+		ptr .v_extending
+		ptr .v_retracting
 
 .h_extending:	dc.b 3
 		dc.b 1, 2

--- a/_anim/Jaws.asm
+++ b/_anim/Jaws.asm
@@ -2,7 +2,8 @@
 ; Animation script - Jaws enemy (LZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Jaws:	dc.w .swim-Ani_Jaws
+Ani_Jaws:	offsetTable
+		ptr .swim
 
 .swim:		dc.b 7
 		dc.b 0, 1, 2, 3

--- a/_anim/Lava Geyser.asm
+++ b/_anim/Lava Geyser.asm
@@ -2,12 +2,13 @@
 ; Animation script - geyser of lava (MZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Geyser:	dc.w .bubble1-Ani_Geyser
-		dc.w .bubble2-Ani_Geyser
-		dc.w .end-Ani_Geyser
-		dc.w .bubble3-Ani_Geyser
-		dc.w .blank-Ani_Geyser
-		dc.w .bubble4-Ani_Geyser
+Ani_Geyser:	offsetTable
+		ptr .bubble1
+		ptr .bubble2
+		ptr .end
+		ptr .bubble3
+		ptr .blank
+		ptr .bubble4
 
 .bubble1:	dc.b 2
 		dc.b 0, 1, 0, 1, 4, 5, 4, 5

--- a/_anim/Monitor.asm
+++ b/_anim/Monitor.asm
@@ -2,16 +2,17 @@
 ; Animation script - monitors
 ; ---------------------------------------------------------------------------
 
-Ani_Monitor:	dc.w .static-Ani_Monitor
-		dc.w .eggman-Ani_Monitor
-		dc.w .sonic-Ani_Monitor
-		dc.w .shoes-Ani_Monitor
-		dc.w .shield-Ani_Monitor
-		dc.w .invincible-Ani_Monitor
-		dc.w .rings-Ani_Monitor
-		dc.w .s-Ani_Monitor
-		dc.w .goggles-Ani_Monitor
-		dc.w .breaking-Ani_Monitor
+Ani_Monitor:	offsetTable
+		ptr .static
+		ptr .eggman
+		ptr .sonic
+		ptr .shoes
+		ptr .shield
+		ptr .invincible
+		ptr .rings
+		ptr .s
+		ptr .goggles
+		ptr .breaking
 
 .static:	dc.b 1
 		dc.b 0, 1, 2

--- a/_anim/Moto Bug.asm
+++ b/_anim/Moto Bug.asm
@@ -2,9 +2,10 @@
 ; Animation script - Motobug enemy (GHZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Moto:	dc.w .stand-Ani_Moto
-		dc.w .drive-Ani_Moto
-		dc.w .smoke-Ani_Moto
+Ani_Moto:	offsetTable
+		ptr .stand
+		ptr .drive
+		ptr .smoke
 
 .stand:		dc.b 15
 		dc.b 2

--- a/_anim/Newtron.asm
+++ b/_anim/Newtron.asm
@@ -2,11 +2,12 @@
 ; Animation script - Newtron enemy
 ; ---------------------------------------------------------------------------
 
-Ani_Newt:	dc.w .blank-Ani_Newt
-		dc.w .drop-Ani_Newt
-		dc.w .fly1-Ani_Newt
-		dc.w .fly2-Ani_Newt
-		dc.w .fires-Ani_Newt
+Ani_Newt:	offsetTable
+		ptr .blank
+		ptr .drop
+		ptr .fly1
+		ptr .fly2
+		ptr .fires
 
 .blank:		dc.b 15
 		dc.b $A

--- a/_anim/Orbinaut.asm
+++ b/_anim/Orbinaut.asm
@@ -2,8 +2,9 @@
 ; Animation script - Orbinaut enemy (LZ/SLZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Orb:	dc.w .normal-Ani_Orb
-		dc.w .angry-Ani_Orb
+Ani_Orb:	offsetTable
+		ptr .normal
+		ptr .angry
 
 .normal:	dc.b 15
 		dc.b 0

--- a/_anim/Plasma Ball Launcher.asm
+++ b/_anim/Plasma Ball Launcher.asm
@@ -2,9 +2,10 @@
 ; Animation script - energy ball launcher in final boss fight (FZ)
 ; ---------------------------------------------------------------------------
 
-Ani_PLaunch:	dc.w .red-Ani_PLaunch
-		dc.w .redsparking-Ani_PLaunch
-		dc.w .whitesparking-Ani_PLaunch
+Ani_PLaunch:	offsetTable
+		ptr .red
+		ptr .redsparking
+		ptr .whitesparking
 
 .red:		dc.b 126
 		dc.b 0

--- a/_anim/Plasma Balls.asm
+++ b/_anim/Plasma Balls.asm
@@ -2,8 +2,9 @@
 ; Animation script - plasma balls in final boss fight (FZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Plasma:	dc.w .full-Ani_Plasma
-		dc.w .short-Ani_Plasma
+Ani_Plasma:	offsetTable
+		ptr .full
+		ptr .short
 
 .full:		dc.b 1
 		dc.b 0, $A, 8, $A, 1, $A, 9, $A, 6, $A, 7, $A, 0, $A, 8, $A

--- a/_anim/Press Start and TM.asm
+++ b/_anim/Press Start and TM.asm
@@ -2,7 +2,8 @@
 ; Animation script - "PRESS START BUTTON" on the title screen (and "TM")
 ; ---------------------------------------------------------------------------
 
-Ani_PSBTM:	dc.w .psbflash-Ani_PSBTM
+Ani_PSBTM:	offsetTable
+		ptr .psbflash
 
 .psbflash:	dc.b 31
 		dc.b 0, 1

--- a/_anim/Prison Capsule.asm
+++ b/_anim/Prison Capsule.asm
@@ -2,8 +2,9 @@
 ; Animation script - prison capsule
 ; ---------------------------------------------------------------------------
 
-Ani_Pri:	dc.w .switchflash-Ani_Pri
-		dc.w .switchflash-Ani_Pri ; redundant
+Ani_Pri:	offsetTable
+		ptr .switchflash
+		ptr .switchflash ; redundant
 
 .switchflash:	dc.b 2
 		dc.b 1, 3

--- a/_anim/Rings.asm
+++ b/_anim/Rings.asm
@@ -2,7 +2,8 @@
 ; Animation script - ring sparkle (rings themselves are animated with Sync2)
 ; ---------------------------------------------------------------------------
 
-Ani_Ring:	dc.w .sparkle-Ani_Ring
+Ani_Ring:	offsetTable
+		ptr .sparkle
 
 .sparkle:	dc.b 5
 		dc.b 4, 5, 6, 7

--- a/_anim/Roller.asm
+++ b/_anim/Roller.asm
@@ -2,9 +2,10 @@
 ; Animation script - Roller enemy (SYZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Roll:	dc.w .unfold-Ani_Roll
-		dc.w .fold-Ani_Roll
-		dc.w .roll-Ani_Roll
+Ani_Roll:	offsetTable
+		ptr .unfold
+		ptr .fold
+		ptr .roll
 
 .unfold:	dc.b 15
 		dc.b 2, 1

--- a/_anim/SBZ Small Door.asm
+++ b/_anim/SBZ Small Door.asm
@@ -2,8 +2,9 @@
 ; Animation script - doors (SBZ)
 ; ---------------------------------------------------------------------------
 
-Ani_ADoor:	dc.w .close-Ani_ADoor
-		dc.w .open-Ani_ADoor
+Ani_ADoor:	offsetTable
+		ptr .close
+		ptr .open
 
 .close:		dc.b 0
 		dc.b 8, 7, 6, 5, 4, 3, 2, 1

--- a/_anim/SBZ Spin Platform Conveyor.asm
+++ b/_anim/SBZ Spin Platform Conveyor.asm
@@ -2,8 +2,9 @@
 ; Animation script - platform on conveyor belt (SBZ)
 ; ---------------------------------------------------------------------------
 
-Ani_SpinConvey:	dc.w .spin-Ani_SpinConvey
-		dc.w .still-Ani_SpinConvey
+Ani_SpinConvey:	offsetTable
+		ptr .spin
+		ptr .still
 
 .spin:		dc.b 0
 		dc.b 0, 1, 2, 3, 4

--- a/_anim/SBZ Spinning Platforms.asm
+++ b/_anim/SBZ Spinning Platforms.asm
@@ -2,10 +2,11 @@
 ; Animation script - trapdoor (SBZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Spin:	dc.w .trapopen-Ani_Spin
-		dc.w .trapclose-Ani_Spin
-		dc.w .spin1-Ani_Spin
-		dc.w .spin2-Ani_Spin
+Ani_Spin:	offsetTable
+		ptr .trapopen
+		ptr .trapclose
+		ptr .spin1
+		ptr .spin2
 
 .trapopen:	dc.b 3
 		dc.b 0, 1

--- a/_anim/SBZ Vanishing Platforms.asm
+++ b/_anim/SBZ Vanishing Platforms.asm
@@ -2,8 +2,9 @@
 ; Animation script - vanishing platforms (SBZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Van:	dc.w .vanish-Ani_Van
-		dc.w .appear-Ani_Van
+Ani_Van:	offsetTable
+		ptr .vanish
+		ptr .appear
 
 .vanish:	dc.b 7
 		dc.b 0, 1, 2

--- a/_anim/Shield and Invincibility.asm
+++ b/_anim/Shield and Invincibility.asm
@@ -2,11 +2,12 @@
 ; Animation script - shield and invincibility stars
 ; ---------------------------------------------------------------------------
 
-Ani_Shield:	dc.w .shield-Ani_Shield
-		dc.w .stars1-Ani_Shield
-		dc.w .stars2-Ani_Shield
-		dc.w .stars3-Ani_Shield
-		dc.w .stars4-Ani_Shield
+Ani_Shield:	offsetTable
+		ptr .shield
+		ptr .stars1
+		ptr .stars2
+		ptr .stars3
+		ptr .stars4
 
 .shield:	dc.b 1
 		dc.b 1, 0, 2, 0, 3, 0

--- a/_anim/Signpost.asm
+++ b/_anim/Signpost.asm
@@ -2,10 +2,11 @@
 ; Animation script - signpost
 ; ---------------------------------------------------------------------------
 
-Ani_Sign:	dc.w .eggman-Ani_Sign
-		dc.w .spin1-Ani_Sign
-		dc.w .spin2-Ani_Sign
-		dc.w .sonic-Ani_Sign
+Ani_Sign:	offsetTable
+		ptr .eggman
+		ptr .spin1
+		ptr .spin2
+		ptr .sonic
 
 .eggman:	dc.b 15
 		dc.b 0

--- a/_anim/Sonic.asm
+++ b/_anim/Sonic.asm
@@ -99,11 +99,11 @@ fr_Slide:	equ $57 ; formerly mamed fr_WaterSlide (was too long...)
 ; Macro to map an ID to a label while defining the offset table entries
 sonani:		macro anim,{INTLABEL},{GLOBALSYMBOLS}
 __LABEL__: =	(*-Ani_Sonic)/2
-		dc.w	anim-Ani_Sonic
+		ptr anim
 		endm
 ; ---------------------------------------------------------------------------
 
-Ani_Sonic:
+Ani_Sonic:	offsetTable
 
 id_Walk:	sonani	SonAni_Walk	; $00
 id_Run:		sonani	SonAni_Run	; $01

--- a/_anim/Special Stage Entry (Unused).asm
+++ b/_anim/Special Stage Entry (Unused).asm
@@ -2,7 +2,8 @@
 ; Animation script - special stage entry effect from beta (unused)
 ; ---------------------------------------------------------------------------
 
-Ani_Vanish:	dc.w .vanish-Ani_Vanish
+Ani_Vanish:	offsetTable
+		ptr .vanish
 
 .vanish:	dc.b 5
 		dc.b 0, 1, 0, 1, 0, 7, 1, 7, 2, 7, 3, 7, 4, 7, 5, 7, 6, 7

--- a/_anim/Springs.asm
+++ b/_anim/Springs.asm
@@ -2,8 +2,9 @@
 ; Animation script - springs
 ; ---------------------------------------------------------------------------
 
-Ani_Spring:	dc.w .updown-Ani_Spring
-		dc.w .leftright-Ani_Spring
+Ani_Spring:	offsetTable
+		ptr .updown
+		ptr .leftright
 
 .updown:	dc.b 0
 		dc.b 1, 0, 0, 2, 2, 2, 2, 2, 2, 0

--- a/_anim/Title Screen Sonic.asm
+++ b/_anim/Title Screen Sonic.asm
@@ -2,7 +2,8 @@
 ; Animation script - Sonic on the title screen
 ; ---------------------------------------------------------------------------
 
-Ani_TSon:	dc.w .titlesonic-Ani_TSon
+Ani_TSon:	offsetTable
+		ptr .titlesonic
 
 .titlesonic:	dc.b 7
 		dc.b 0, 1, 2, 3, 4, 5 ; popping up

--- a/_anim/Try Again & End Eggman.asm
+++ b/_anim/Try Again & End Eggman.asm
@@ -2,9 +2,10 @@
 ; Animation script - Eggman on the "TRY AGAIN" and "END" screens
 ; ---------------------------------------------------------------------------
 
-Ani_EEgg:	dc.w .tryagain1-Ani_EEgg
-		dc.w .tryagain2-Ani_EEgg
-		dc.w .endtantrum-Ani_EEgg
+Ani_EEgg:	offsetTable
+		ptr .tryagain1
+		ptr .tryagain2
+		ptr .endtantrum
 
 .tryagain1:	dc.b 5
 		dc.b 0

--- a/_anim/Wall of Lava.asm
+++ b/_anim/Wall of Lava.asm
@@ -2,7 +2,8 @@
 ; Animation script - advancing wall of lava (MZ act 2)
 ; ---------------------------------------------------------------------------
 
-Ani_LWall:	dc.w .lavawall-Ani_LWall
+Ani_LWall:	offsetTable
+		ptr .lavawall
 
 .lavawall:	dc.b 9
 		dc.b 0, 1, 2, 3

--- a/_anim/Water Splash.asm
+++ b/_anim/Water Splash.asm
@@ -2,7 +2,8 @@
 ; Animation script - water splash (LZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Splash:	dc.w .splash-Ani_Splash
+Ani_Splash:	offsetTable
+		ptr .splash
 
 .splash:	dc.b 4
 		dc.b 0, 1, 2

--- a/_anim/Waterfalls.asm
+++ b/_anim/Waterfalls.asm
@@ -2,7 +2,8 @@
 ; Animation script - waterfall (LZ)
 ; ---------------------------------------------------------------------------
 
-Ani_WFall:	dc.w .splash-Ani_WFall
+Ani_WFall:	offsetTable
+		ptr .splash
 
 .splash:	dc.b 5
 		dc.b 9, $A, $B

--- a/_anim/Yadrin.asm
+++ b/_anim/Yadrin.asm
@@ -2,8 +2,9 @@
 ; Animation script - Yadrin enemy (SYZ)
 ; ---------------------------------------------------------------------------
 
-Ani_Yad:	dc.w .stand-Ani_Yad
-		dc.w .walk-Ani_Yad
+Ani_Yad:	offsetTable
+		ptr .stand
+		ptr .walk
 
 .stand:		dc.b 7
 		dc.b 0

--- a/_inc/AnimateLevelGfx.asm
+++ b/_inc/AnimateLevelGfx.asm
@@ -17,14 +17,15 @@ AnimateLevelGfx:
 		rts
 
 ; ===========================================================================
-AniArt_Index:	dc.w AniArt_GHZ-AniArt_Index	; GHZ
-		dc.w AniArt_none-AniArt_Index	; LZ (unused)
-		dc.w AniArt_MZ-AniArt_Index	; MZ
-		dc.w AniArt_none-AniArt_Index	; SLZ (unused)
-		dc.w AniArt_none-AniArt_Index	; SYZ (unused)
-		dc.w AniArt_SBZ-AniArt_Index	; SBZ
+AniArt_Index:	offsetTable
+		ptr AniArt_GHZ		; GHZ
+		ptr AniArt_none		; LZ (unused)
+		ptr AniArt_MZ		; MZ
+		ptr AniArt_none		; SLZ (unused)
+		ptr AniArt_none		; SYZ (unused)
+		ptr AniArt_SBZ		; SBZ
 		zonewarning AniArt_Index,2
-		dc.w AniArt_Ending-AniArt_Index	; ending sequence
+		ptr AniArt_Ending	; ending sequence
 
 ; ===========================================================================
 ; ---------------------------------------------------------------------------
@@ -406,22 +407,23 @@ LoadTiles:
 ; ---------------------------------------------------------------------------
 ; Animated pattern routine - more Marble Zone
 ; ---------------------------------------------------------------------------
-AniArt_MZextra:	dc.w AniArt_MZ_Magma_Shift0_Col0-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift1_Col0-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift2_Col0-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift3_Col0-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift0_Col1-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift1_Col1-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift2_Col1-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift3_Col1-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift0_Col2-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift1_Col2-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift2_Col2-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift3_Col2-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift0_Col3-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift1_Col3-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift2_Col3-AniArt_MZextra
-		dc.w AniArt_MZ_Magma_Shift3_Col3-AniArt_MZextra
+AniArt_MZextra:	offsetTable
+		ptr AniArt_MZ_Magma_Shift0_Col0
+		ptr AniArt_MZ_Magma_Shift1_Col0
+		ptr AniArt_MZ_Magma_Shift2_Col0
+		ptr AniArt_MZ_Magma_Shift3_Col0
+		ptr AniArt_MZ_Magma_Shift0_Col1
+		ptr AniArt_MZ_Magma_Shift1_Col1
+		ptr AniArt_MZ_Magma_Shift2_Col1
+		ptr AniArt_MZ_Magma_Shift3_Col1
+		ptr AniArt_MZ_Magma_Shift0_Col2
+		ptr AniArt_MZ_Magma_Shift1_Col2
+		ptr AniArt_MZ_Magma_Shift2_Col2
+		ptr AniArt_MZ_Magma_Shift3_Col2
+		ptr AniArt_MZ_Magma_Shift0_Col3
+		ptr AniArt_MZ_Magma_Shift1_Col3
+		ptr AniArt_MZ_Magma_Shift2_Col3
+		ptr AniArt_MZ_Magma_Shift3_Col3
 ; ===========================================================================
 
 ; loc_1C3EE:

--- a/_inc/DebugList.asm
+++ b/_inc/DebugList.asm
@@ -1,15 +1,15 @@
 ; ---------------------------------------------------------------------------
 ; Debug mode item lists
 ; ---------------------------------------------------------------------------
-DebugList:
-		dc.w .GHZ-DebugList
-		dc.w .LZ-DebugList
-		dc.w .MZ-DebugList
-		dc.w .SLZ-DebugList
-		dc.w .SYZ-DebugList
-		dc.w .SBZ-DebugList
+DebugList:	offsetTable
+		ptr .GHZ
+		ptr .LZ
+		ptr .MZ
+		ptr .SLZ
+		ptr .SYZ
+		ptr .SBZ
 		zonewarning DebugList,2
-		dc.w .Ending-DebugList
+		ptr .Ending
 
 dbug:	macro map,object,subtype,frame,vram
 		dc.l map+(object<<24)

--- a/_inc/DeformLayers (REV00).asm
+++ b/_inc/DeformLayers (REV00).asm
@@ -33,14 +33,15 @@ DeformLayers:
 ; ---------------------------------------------------------------------------
 ; Offset index for background layer deformation code
 ; ---------------------------------------------------------------------------
-Deform_Index:	dc.w Deform_GHZ-Deform_Index
-		dc.w Deform_LZ-Deform_Index
-		dc.w Deform_MZ-Deform_Index
-		dc.w Deform_SLZ-Deform_Index
-		dc.w Deform_SYZ-Deform_Index
-		dc.w Deform_SBZ-Deform_Index
+Deform_Index:	offsetTable
+		ptr Deform_GHZ
+		ptr Deform_LZ
+		ptr Deform_MZ
+		ptr Deform_SLZ
+		ptr Deform_SYZ
+		ptr Deform_SBZ
 		zonewarning Deform_Index,2
-		dc.w Deform_GHZ-Deform_Index
+		ptr Deform_GHZ
 
 ; ===========================================================================
 ; ---------------------------------------------------------------------------

--- a/_inc/DeformLayers (REV01).asm
+++ b/_inc/DeformLayers (REV01).asm
@@ -29,14 +29,15 @@ DeformLayers:
 ; ---------------------------------------------------------------------------
 ; Offset index for background layer deformation code
 ; ---------------------------------------------------------------------------
-Deform_Index:	dc.w Deform_GHZ-Deform_Index
-		dc.w Deform_LZ-Deform_Index
-		dc.w Deform_MZ-Deform_Index
-		dc.w Deform_SLZ-Deform_Index
-		dc.w Deform_SYZ-Deform_Index
-		dc.w Deform_SBZ-Deform_Index
+Deform_Index:	offsetTable
+		ptr Deform_GHZ
+		ptr Deform_LZ
+		ptr Deform_MZ
+		ptr Deform_SLZ
+		ptr Deform_SYZ
+		ptr Deform_SBZ
 		zonewarning Deform_Index,2
-		dc.w Deform_GHZ-Deform_Index
+		ptr Deform_GHZ
 
 ; ===========================================================================
 ; ---------------------------------------------------------------------------

--- a/_inc/DynamicLevelEvents.asm
+++ b/_inc/DynamicLevelEvents.asm
@@ -49,14 +49,15 @@ loc_6DC4:
 ; ---------------------------------------------------------------------------
 ; Offset index for dynamic level events
 ; ---------------------------------------------------------------------------
-DLE_Index:	dc.w DLE_GHZ-DLE_Index
-		dc.w DLE_LZ-DLE_Index
-		dc.w DLE_MZ-DLE_Index
-		dc.w DLE_SLZ-DLE_Index
-		dc.w DLE_SYZ-DLE_Index
-		dc.w DLE_SBZ-DLE_Index
+DLE_Index:	offsetTable
+		ptr DLE_GHZ
+		ptr DLE_LZ
+		ptr DLE_MZ
+		ptr DLE_SLZ
+		ptr DLE_SYZ
+		ptr DLE_SBZ
 		zonewarning DLE_Index,2
-		dc.w DLE_Ending-DLE_Index
+		ptr DLE_Ending
 
 ; ===========================================================================
 ; ---------------------------------------------------------------------------
@@ -70,9 +71,10 @@ DLE_GHZ:
 		move.w	DLE_GHZx(pc,d0.w),d0
 		jmp	DLE_GHZx(pc,d0.w)
 ; ===========================================================================
-DLE_GHZx:	dc.w DLE_GHZ1-DLE_GHZx
-		dc.w DLE_GHZ2-DLE_GHZx
-		dc.w DLE_GHZ3-DLE_GHZx
+DLE_GHZx:	offsetTable
+		ptr DLE_GHZ1
+		ptr DLE_GHZ2
+		ptr DLE_GHZ3
 ; ===========================================================================
 
 DLE_GHZ1:
@@ -112,9 +114,10 @@ DLE_GHZ3:
 		move.w	off_6E4A(pc,d0.w),d0
 		jmp	off_6E4A(pc,d0.w)
 ; ===========================================================================
-off_6E4A:	dc.w DLE_GHZ3main-off_6E4A
-		dc.w DLE_GHZ3boss-off_6E4A
-		dc.w DLE_GHZ3end-off_6E4A
+off_6E4A:	offsetTable
+		ptr DLE_GHZ3main
+		ptr DLE_GHZ3boss
+		ptr DLE_GHZ3end
 ; ===========================================================================
 
 DLE_GHZ3main:
@@ -189,10 +192,11 @@ DLE_LZ:
 		move.w	DLE_LZx(pc,d0.w),d0
 		jmp	DLE_LZx(pc,d0.w)
 ; ===========================================================================
-DLE_LZx:	dc.w DLE_LZ12-DLE_LZx
-		dc.w DLE_LZ12-DLE_LZx
-		dc.w DLE_LZ3-DLE_LZx
-		dc.w DLE_SBZ3-DLE_LZx
+DLE_LZx:	offsetTable
+		ptr DLE_LZ12
+		ptr DLE_LZ12
+		ptr DLE_LZ3
+		ptr DLE_SBZ3
 ; ===========================================================================
 
 DLE_LZ12:
@@ -262,9 +266,10 @@ DLE_MZ:
 		move.w	DLE_MZx(pc,d0.w),d0
 		jmp	DLE_MZx(pc,d0.w)
 ; ===========================================================================
-DLE_MZx:	dc.w DLE_MZ1-DLE_MZx
-		dc.w DLE_MZ2-DLE_MZx
-		dc.w DLE_MZ3-DLE_MZx
+DLE_MZx:	offsetTable
+		ptr DLE_MZ1
+		ptr DLE_MZ2
+		ptr DLE_MZ3
 ; ===========================================================================
 
 DLE_MZ1:
@@ -273,10 +278,11 @@ DLE_MZ1:
 		move.w	off_6FB2(pc,d0.w),d0
 		jmp	off_6FB2(pc,d0.w)
 ; ===========================================================================
-off_6FB2:	dc.w DLE_MZ1_0-off_6FB2
-		dc.w DLE_MZ1_2-off_6FB2
-		dc.w DLE_MZ1_4-off_6FB2
-		dc.w DLE_MZ1_6-off_6FB2
+off_6FB2:	offsetTable
+		ptr DLE_MZ1_0
+		ptr DLE_MZ1_2
+		ptr DLE_MZ1_4
+		ptr DLE_MZ1_6
 ; ===========================================================================
 
 ; loc_6FBA:
@@ -389,8 +395,9 @@ DLE_MZ3:
 		move.w	off_7098(pc,d0.w),d0
 		jmp	off_7098(pc,d0.w)
 ; ===========================================================================
-off_7098:	dc.w DLE_MZ3boss-off_7098
-		dc.w DLE_MZ3end-off_7098
+off_7098:	offsetTable
+		ptr DLE_MZ3boss
+		ptr DLE_MZ3end
 ; ===========================================================================
 
 DLE_MZ3boss:
@@ -435,9 +442,10 @@ DLE_SLZ:
 		move.w	DLE_SLZx(pc,d0.w),d0
 		jmp	DLE_SLZx(pc,d0.w)
 ; ===========================================================================
-DLE_SLZx:	dc.w DLE_SLZ12-DLE_SLZx
-		dc.w DLE_SLZ12-DLE_SLZx
-		dc.w DLE_SLZ3-DLE_SLZx
+DLE_SLZx:	offsetTable
+		ptr DLE_SLZ12
+		ptr DLE_SLZ12
+		ptr DLE_SLZ3
 ; ===========================================================================
 
 DLE_SLZ12:
@@ -450,9 +458,10 @@ DLE_SLZ3:
 		move.w	off_7118(pc,d0.w),d0
 		jmp	off_7118(pc,d0.w)
 ; ===========================================================================
-off_7118:	dc.w DLE_SLZ3main-off_7118
-		dc.w DLE_SLZ3boss-off_7118
-		dc.w DLE_SLZ3end-off_7118
+off_7118:	offsetTable
+		ptr DLE_SLZ3main
+		ptr DLE_SLZ3boss
+		ptr DLE_SLZ3end
 ; ===========================================================================
 
 DLE_SLZ3main:
@@ -502,9 +511,10 @@ DLE_SYZ:
 		move.w	DLE_SYZx(pc,d0.w),d0
 		jmp	DLE_SYZx(pc,d0.w)
 ; ===========================================================================
-DLE_SYZx:	dc.w DLE_SYZ1-DLE_SYZx
-		dc.w DLE_SYZ2-DLE_SYZx
-		dc.w DLE_SYZ3-DLE_SYZx
+DLE_SYZx:	offsetTable
+		ptr DLE_SYZ1
+		ptr DLE_SYZ2
+		ptr DLE_SYZ3
 ; ===========================================================================
 
 DLE_SYZ1:
@@ -530,9 +540,10 @@ DLE_SYZ3:
 		move.w	off_71B2(pc,d0.w),d0
 		jmp	off_71B2(pc,d0.w)
 ; ===========================================================================
-off_71B2:	dc.w DLE_SYZ3main-off_71B2
-		dc.w DLE_SYZ3boss-off_71B2
-		dc.w DLE_SYZ3end-off_71B2
+off_71B2:	offsetTable
+		ptr DLE_SYZ3main
+		ptr DLE_SYZ3boss
+		ptr DLE_SYZ3end
 ; ===========================================================================
 
 DLE_SYZ3main:
@@ -584,9 +595,10 @@ DLE_SBZ:
 		move.w	DLE_SBZx(pc,d0.w),d0
 		jmp	DLE_SBZx(pc,d0.w)
 ; ===========================================================================
-DLE_SBZx:	dc.w DLE_SBZ1-DLE_SBZx
-		dc.w DLE_SBZ2-DLE_SBZx
-		dc.w DLE_FZ-DLE_SBZx
+DLE_SBZx:	offsetTable
+		ptr DLE_SBZ1
+		ptr DLE_SBZ2
+		ptr DLE_FZ
 ; ===========================================================================
 
 DLE_SBZ1:
@@ -608,10 +620,11 @@ DLE_SBZ2:
 		move.w	off_7252(pc,d0.w),d0
 		jmp	off_7252(pc,d0.w)
 ; ===========================================================================
-off_7252:	dc.w DLE_SBZ2main-off_7252
-		dc.w DLE_SBZ2boss-off_7252
-		dc.w DLE_SBZ2boss2-off_7252
-		dc.w DLE_SBZ2end-off_7252
+off_7252:	offsetTable
+		ptr DLE_SBZ2main
+		ptr DLE_SBZ2boss
+		ptr DLE_SBZ2boss2
+		ptr DLE_SBZ2end
 ; ===========================================================================
 
 DLE_SBZ2main:
@@ -674,11 +687,12 @@ DLE_FZ:
 		move.w	off_72D8(pc,d0.w),d0
 		jmp	off_72D8(pc,d0.w)
 ; ===========================================================================
-off_72D8:	dc.w DLE_FZmain-off_72D8
-		dc.w DLE_FZboss-off_72D8
-		dc.w DLE_FZend-off_72D8
-		dc.w DLE_FZwait-off_72D8
-		dc.w DLE_FZend2-off_72D8
+off_72D8:	offsetTable
+		ptr DLE_FZmain
+		ptr DLE_FZboss
+		ptr DLE_FZend
+		ptr DLE_FZwait
+		ptr DLE_FZend2
 ; ===========================================================================
 
 DLE_FZmain:

--- a/_inc/LZWaterFeatures.asm
+++ b/_inc/LZWaterFeatures.asm
@@ -77,10 +77,11 @@ LZDynamicWater:
 .exit:
 		rts
 ; ===========================================================================
-DynWater_Index:	dc.w DynWater_LZ1-DynWater_Index
-		dc.w DynWater_LZ2-DynWater_Index
-		dc.w DynWater_LZ3-DynWater_Index
-		dc.w DynWater_SBZ3-DynWater_Index
+DynWater_Index:	offsetTable
+		ptr DynWater_LZ1
+		ptr DynWater_LZ2
+		ptr DynWater_LZ3
+		ptr DynWater_SBZ3
 ; ===========================================================================
 
 DynWater_LZ1:

--- a/_inc/LevelSizeLoad & BgScrollSpeed.asm
+++ b/_inc/LevelSizeLoad & BgScrollSpeed.asm
@@ -266,14 +266,15 @@ loc_6206:
 ; End of function BgScrollSpeed
 
 ; ===========================================================================
-BgScroll_Index:	dc.w BgScroll_GHZ-BgScroll_Index
-		dc.w BgScroll_LZ-BgScroll_Index
-		dc.w BgScroll_MZ-BgScroll_Index
-		dc.w BgScroll_SLZ-BgScroll_Index
-		dc.w BgScroll_SYZ-BgScroll_Index
-		dc.w BgScroll_SBZ-BgScroll_Index
+BgScroll_Index:	offsetTable
+		ptr BgScroll_GHZ
+		ptr BgScroll_LZ
+		ptr BgScroll_MZ
+		ptr BgScroll_SLZ
+		ptr BgScroll_SYZ
+		ptr BgScroll_SBZ
 		zonewarning BgScroll_Index,2
-		dc.w BgScroll_End-BgScroll_Index
+		ptr BgScroll_End
 ; ===========================================================================
 
 BgScroll_GHZ:

--- a/_inc/ObjPosLoad.asm
+++ b/_inc/ObjPosLoad.asm
@@ -10,8 +10,9 @@ ObjPosLoad:
 ; End of function ObjPosLoad
 
 ; ===========================================================================
-OPL_Index:	dc.w OPL_Main-OPL_Index
-		dc.w OPL_Next-OPL_Index
+OPL_Index:	offsetTable
+		ptr OPL_Main
+		ptr OPL_Next
 ; ===========================================================================
 
 OPL_Main:

--- a/_inc/PaletteCycle.asm
+++ b/_inc/PaletteCycle.asm
@@ -15,14 +15,15 @@ PaletteCycle:
 ; ---------------------------------------------------------------------------
 ; Palette cycling routines
 ; ---------------------------------------------------------------------------
-PalCycle_Index:	dc.w PalCycle_GHZ-PalCycle_Index
-		dc.w PalCycle_LZ-PalCycle_Index
-		dc.w PalCycle_MZ-PalCycle_Index
-		dc.w PalCycle_SLZ-PalCycle_Index
-		dc.w PalCycle_SYZ-PalCycle_Index
-		dc.w PalCycle_SBZ-PalCycle_Index
+PalCycle_Index:	offsetTable
+		ptr PalCycle_GHZ
+		ptr PalCycle_LZ
+		ptr PalCycle_MZ
+		ptr PalCycle_SLZ
+		ptr PalCycle_SYZ
+		ptr PalCycle_SBZ
 		zonewarning PalCycle_Index,2
-		dc.w PalCycle_GHZ-PalCycle_Index	; Ending
+		ptr PalCycle_GHZ	; Ending
 ; ===========================================================================
 
 PalCycle_Title:

--- a/_inc/Pattern Load Cues.asm
+++ b/_inc/Pattern Load Cues.asm
@@ -5,12 +5,12 @@
 ; Macro to define PLC pointer entry
 plcptr:		macro plc,{INTLABEL},{GLOBALSYMBOLS}
 __LABEL__: =	(*-ArtLoadCues)/2
-		dc.w	plc-ArtLoadCues
+		ptr plc
 		endm
 
 ; Macro for the header of a PLC list
 plcheader:	macro {INTLABEL},{GLOBALSYMBOLS}
-__LABEL__:	dc.w ((__LABEL___end-__LABEL__-2)/6)-1
+__LABEL__:	dc.w ((__LABEL___end-__LABEL__-2)/plc_slot_size)-1
 		endm
 
 ; Macro for single pattern load cue entry
@@ -22,7 +22,7 @@ plcm:		macro gfx,vram
 ; ---------------------------------------------------------------------------
 
 ; Index and ID definitions
-ArtLoadCues:
+ArtLoadCues:		offsetTable
 
 plcid_Main:		plcptr	PLC_Main
 plcid_Main2:		plcptr	PLC_Main2

--- a/_incObj/01 Sonic.asm
+++ b/_incObj/01 Sonic.asm
@@ -18,11 +18,12 @@ Sonic_Normal:
 		jmp	Sonic_Index(pc,d1.w)			; jump there
 ; ===========================================================================
 ; Obj01_Index:
-Sonic_Index:	dc.w Sonic_Main-Sonic_Index			; 0 - object init
-		dc.w Sonic_Control-Sonic_Index			; 2 - main mode
-		dc.w Sonic_Hurt-Sonic_Index			; 4 - while being knocked back from damage
-		dc.w Sonic_Death-Sonic_Index			; 6 - while dying and falling off screen
-		dc.w Sonic_ResetLevel-Sonic_Index		; 8 - after having died and waiting for the level to restart
+Sonic_Index:	offsetTable
+		ptr Sonic_Main					; 0 - object init
+		ptr Sonic_Control				; 2 - main mode
+		ptr Sonic_Hurt					; 4 - while being knocked back from damage
+		ptr Sonic_Death					; 6 - while dying and falling off screen
+		ptr Sonic_ResetLevel				; 8 - after having died and waiting for the level to restart
 ; ===========================================================================
 
 ; Obj01_Main:
@@ -103,10 +104,11 @@ Sonic_Control:	; Routine 2
 ; This jump table uses Sonic's actual state bits in obStatus for the index.
 ; ---------------------------------------------------------------------------
 ; Obj01_Modes:
-Sonic_Modes:	dc.w Sonic_MdNormal-Sonic_Modes			; 0 - while on the ground and not rolling
-		dc.w Sonic_MdJump-Sonic_Modes			; 2 - while in the air and not rolling
-		dc.w Sonic_MdRoll-Sonic_Modes			; 4 - while on the ground and rolling
-		dc.w Sonic_MdJump2-Sonic_Modes			; 6 - while in the air and rolling
+Sonic_Modes:	offsetTable
+		ptr Sonic_MdNormal				; 0 - while on the ground and not rolling
+		ptr Sonic_MdJump				; 2 - while in the air and not rolling
+		ptr Sonic_MdRoll				; 4 - while on the ground and rolling
+		ptr Sonic_MdJump2				; 6 - while in the air and rolling
 
 
 ; ===========================================================================

--- a/_incObj/08 Water Splash.asm
+++ b/_incObj/08 Water Splash.asm
@@ -8,9 +8,10 @@ Splash:
 		move.w	Spla_Index(pc,d0.w),d1
 		jmp	Spla_Index(pc,d1.w)
 ; ===========================================================================
-Spla_Index:	dc.w Spla_Main-Spla_Index
-		dc.w Spla_Display-Spla_Index
-		dc.w Spla_Delete-Spla_Index
+Spla_Index:	offsetTable
+		ptr Spla_Main
+		ptr Spla_Display
+		ptr Spla_Delete
 ; ===========================================================================
 
 Spla_Main:	; Routine 0

--- a/_incObj/09 Sonic in Special Stage.asm
+++ b/_incObj/09 Sonic in Special Stage.asm
@@ -15,10 +15,11 @@ Obj09_Normal:
 		move.w	Obj09_Index(pc,d0.w),d1
 		jmp	Obj09_Index(pc,d1.w)
 ; ===========================================================================
-Obj09_Index:	dc.w Obj09_Main-Obj09_Index
-		dc.w Obj09_ChkDebug-Obj09_Index
-		dc.w Obj09_ExitStage-Obj09_Index
-		dc.w Obj09_Exit2-Obj09_Index
+Obj09_Index:	offsetTable
+		ptr Obj09_Main
+		ptr Obj09_ChkDebug
+		ptr Obj09_ExitStage
+		ptr Obj09_Exit2
 ; ===========================================================================
 
 Obj09_Main:	; Routine 0
@@ -50,8 +51,9 @@ Obj09_NoDebug:
 		jsr	(Sonic_LoadGfx).l
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-Obj09_Modes:	dc.w Obj09_OnWall-Obj09_Modes
-		dc.w Obj09_InAir-Obj09_Modes
+Obj09_Modes:	offsetTable
+		ptr Obj09_OnWall
+		ptr Obj09_InAir
 ; ===========================================================================
 
 Obj09_OnWall:

--- a/_incObj/0A Drowning Countdown.asm
+++ b/_incObj/0A Drowning Countdown.asm
@@ -9,15 +9,16 @@ DrownCount:
 		move.w	Drown_Index(pc,d0.w),d1
 		jmp	Drown_Index(pc,d1.w)
 ; ===========================================================================
-Drown_Index:	dc.w Drown_Main-Drown_Index
-		dc.w Drown_Animate-Drown_Index
-		dc.w Drown_ChkWater-Drown_Index
-		dc.w Drown_Display-Drown_Index
-		dc.w Drown_Delete-Drown_Index
-		dc.w Drown_Countdown-Drown_Index
-		dc.w Drown_AirLeft-Drown_Index
-		dc.w Drown_Display-Drown_Index
-		dc.w Drown_Delete-Drown_Index
+Drown_Index:	offsetTable
+		ptr Drown_Main
+		ptr Drown_Animate
+		ptr Drown_ChkWater
+		ptr Drown_Display
+		ptr Drown_Delete
+		ptr Drown_Countdown
+		ptr Drown_AirLeft
+		ptr Drown_Display
+		ptr Drown_Delete
 
 drown_origX = objoff_30		; original x-axis position
 drown_time = objoff_38		; time between each number changes

--- a/_incObj/0B Pole that Breaks.asm
+++ b/_incObj/0B Pole that Breaks.asm
@@ -8,9 +8,10 @@ Pole:
 		move.w	Pole_Index(pc,d0.w),d1
 		jmp	Pole_Index(pc,d1.w)
 ; ===========================================================================
-Pole_Index:	dc.w Pole_Main-Pole_Index
-		dc.w Pole_Action-Pole_Index
-		dc.w Pole_Display-Pole_Index
+Pole_Index:	offsetTable
+		ptr Pole_Main
+		ptr Pole_Action
+		ptr Pole_Display
 
 pole_time = objoff_30		; time between grabbing the pole & breaking
 pole_grabbed = objoff_32		; flag set when Sonic grabs the pole

--- a/_incObj/0C Flapping Door.asm
+++ b/_incObj/0C Flapping Door.asm
@@ -8,8 +8,9 @@ FlapDoor:
 		move.w	Flap_Index(pc,d0.w),d1
 		jmp	Flap_Index(pc,d1.w)
 ; ===========================================================================
-Flap_Index:	dc.w Flap_Main-Flap_Index
-		dc.w Flap_OpenClose-Flap_Index
+Flap_Index:	offsetTable
+		ptr Flap_Main
+		ptr Flap_OpenClose
 
 flap_time = objoff_32		; time between opening/closing
 flap_wait = objoff_30		; time until change

--- a/_incObj/0D Signpost.asm
+++ b/_incObj/0D Signpost.asm
@@ -13,11 +13,12 @@ Signpost:
 		out_of_range.w	DeleteObject
 		rts
 ; ===========================================================================
-Sign_Index:	dc.w Sign_Main-Sign_Index
-		dc.w Sign_Touch-Sign_Index
-		dc.w Sign_Spin-Sign_Index
-		dc.w Sign_SonicRun-Sign_Index
-		dc.w Sign_Exit-Sign_Index
+Sign_Index:	offsetTable
+		ptr Sign_Main
+		ptr Sign_Touch
+		ptr Sign_Spin
+		ptr Sign_SonicRun
+		ptr Sign_Exit
 
 spintime = objoff_30		; time for signpost to spin
 sparkletime = objoff_32		; time between sparkles

--- a/_incObj/0E Title Screen Sonic.asm
+++ b/_incObj/0E Title Screen Sonic.asm
@@ -8,10 +8,11 @@ TitleSonic:
 		move.w	TSon_Index(pc,d0.w),d1
 		jmp	TSon_Index(pc,d1.w)
 ; ===========================================================================
-TSon_Index:	dc.w TSon_Main-TSon_Index
-		dc.w TSon_Delay-TSon_Index
-		dc.w TSon_Move-TSon_Index
-		dc.w TSon_Animate-TSon_Index
+TSon_Index:	offsetTable
+		ptr TSon_Main
+		ptr TSon_Delay
+		ptr TSon_Move
+		ptr TSon_Animate
 ; ===========================================================================
 
 TSon_Main:	; Routine 0

--- a/_incObj/0F Press Start and TM.asm
+++ b/_incObj/0F Press Start and TM.asm
@@ -9,9 +9,10 @@ PSBTM:
 		jsr	PSB_Index(pc,d1.w)
 		bra.w	DisplaySprite
 ; ===========================================================================
-PSB_Index:	dc.w PSB_Main-PSB_Index
-		dc.w PSB_PrsStart-PSB_Index
-		dc.w PSB_Exit-PSB_Index
+PSB_Index:	offsetTable
+		ptr PSB_Main
+		ptr PSB_PrsStart
+		ptr PSB_Exit
 ; ===========================================================================
 
 PSB_Main:	; Routine 0

--- a/_incObj/11 Bridge.asm
+++ b/_incObj/11 Bridge.asm
@@ -8,12 +8,13 @@ Bridge:
 		move.w	Bri_Index(pc,d0.w),d1
 		jmp	Bri_Index(pc,d1.w)
 ; ===========================================================================
-Bri_Index:	dc.w Bri_Main-Bri_Index
-		dc.w Bri_Action-Bri_Index
-		dc.w Bri_Platform-Bri_Index
-		dc.w Bri_Delete-Bri_Index
-		dc.w Bri_Delete-Bri_Index
-		dc.w Bri_Display-Bri_Index
+Bri_Index:	offsetTable
+		ptr Bri_Main
+		ptr Bri_Action
+		ptr Bri_Platform
+		ptr Bri_Delete
+		ptr Bri_Delete
+		ptr Bri_Display
 ; ===========================================================================
 
 Bri_Main:	; Routine 0

--- a/_incObj/12 Light.asm
+++ b/_incObj/12 Light.asm
@@ -8,8 +8,9 @@ SpinningLight:
 		move.w	Light_Index(pc,d0.w),d1
 		jmp	Light_Index(pc,d1.w)
 ; ===========================================================================
-Light_Index:	dc.w Light_Main-Light_Index
-		dc.w Light_Animate-Light_Index
+Light_Index:	offsetTable
+		ptr Light_Main
+		ptr Light_Animate
 ; ===========================================================================
 
 Light_Main:	; Routine 0

--- a/_incObj/13 Lava Ball Maker.asm
+++ b/_incObj/13 Lava Ball Maker.asm
@@ -15,8 +15,9 @@ LavaMaker:
 		bra.w	LBall_ChkDel
 	endif
 ; ===========================================================================
-LavaM_Index:	dc.w LavaM_Main-LavaM_Index
-		dc.w LavaM_MakeLava-LavaM_Index
+LavaM_Index:	offsetTable
+		ptr LavaM_Main
+		ptr LavaM_MakeLava
 ; ---------------------------------------------------------------------------
 ;
 ; Lava ball production rates

--- a/_incObj/14 Lava Ball.asm
+++ b/_incObj/14 Lava Ball.asm
@@ -13,9 +13,10 @@ LavaBall:
 		bra.w	DisplaySprite
 	endif
 ; ===========================================================================
-LBall_Index:	dc.w LBall_Main-LBall_Index
-		dc.w LBall_Action-LBall_Index
-		dc.w LBall_Delete-LBall_Index
+LBall_Index:	offsetTable
+		ptr LBall_Main
+		ptr LBall_Action
+		ptr LBall_Delete
 
 LBall_Speeds:	dc.w -$400, -$500, -$600, -$700, -$200
 		dc.w $200, -$200, $200,	0
@@ -76,15 +77,16 @@ LBall_ChkDel:
 		rts
 	endif
 ; ===========================================================================
-LBall_TypeIndex:dc.w LBall_Type00-LBall_TypeIndex
-		dc.w LBall_Type00-LBall_TypeIndex
-		dc.w LBall_Type00-LBall_TypeIndex
-		dc.w LBall_Type00-LBall_TypeIndex
-		dc.w LBall_Type04-LBall_TypeIndex
-		dc.w LBall_Type05-LBall_TypeIndex
-		dc.w LBall_Type06-LBall_TypeIndex
-		dc.w LBall_Type07-LBall_TypeIndex
-		dc.w LBall_Type08-LBall_TypeIndex
+LBall_TypeIndex: offsetTable
+		ptr LBall_Type00
+		ptr LBall_Type00
+		ptr LBall_Type00
+		ptr LBall_Type00
+		ptr LBall_Type04
+		ptr LBall_Type05
+		ptr LBall_Type06
+		ptr LBall_Type07
+		ptr LBall_Type08
 ; ===========================================================================
 ; lavaball types 00-03 fly up and fall back down
 

--- a/_incObj/15 Swinging Platforms.asm
+++ b/_incObj/15 Swinging Platforms.asm
@@ -9,13 +9,14 @@ SwingingPlatform:
 		move.w	Swing_Index(pc,d0.w),d1
 		jmp	Swing_Index(pc,d1.w)
 ; ===========================================================================
-Swing_Index:	dc.w Swing_Main-Swing_Index
-		dc.w Swing_SetSolid-Swing_Index
-		dc.w Swing_Action2-Swing_Index
-		dc.w Swing_Delete-Swing_Index
-		dc.w Swing_Delete-Swing_Index
-		dc.w Swing_Display-Swing_Index
-		dc.w Swing_Action-Swing_Index
+Swing_Index:	offsetTable
+		ptr Swing_Main
+		ptr Swing_SetSolid
+		ptr Swing_Action2
+		ptr Swing_Delete
+		ptr Swing_Delete
+		ptr Swing_Display
+		ptr Swing_Action
 
 swing_origX = objoff_3A		; original x-axis position
 swing_origY = objoff_38		; original y-axis position

--- a/_incObj/16 Harpoon.asm
+++ b/_incObj/16 Harpoon.asm
@@ -8,9 +8,10 @@ Harpoon:
 		move.w	Harp_Index(pc,d0.w),d1
 		jmp	Harp_Index(pc,d1.w)
 ; ===========================================================================
-Harp_Index:	dc.w Harp_Main-Harp_Index
-		dc.w Harp_Move-Harp_Index
-		dc.w Harp_Wait-Harp_Index
+Harp_Index:	offsetTable
+		ptr Harp_Main
+		ptr Harp_Move
+		ptr Harp_Wait
 
 harp_time = objoff_30		; time between stabbing/retracting
 ; ===========================================================================

--- a/_incObj/17 Spiked Pole Helix.asm
+++ b/_incObj/17 Spiked Pole Helix.asm
@@ -8,11 +8,12 @@ Helix:
 		move.w	Hel_Index(pc,d0.w),d1
 		jmp	Hel_Index(pc,d1.w)
 ; ===========================================================================
-Hel_Index:	dc.w Hel_Main-Hel_Index
-		dc.w Hel_Action-Hel_Index
-		dc.w Hel_Action-Hel_Index
-		dc.w Hel_Delete-Hel_Index
-		dc.w Hel_Display-Hel_Index
+Hel_Index:	offsetTable
+		ptr Hel_Main
+		ptr Hel_Action
+		ptr Hel_Action
+		ptr Hel_Delete
+		ptr Hel_Display
 
 hel_frame = objoff_3E		; start frame (different for each spike)
 

--- a/_incObj/18 Platforms.asm
+++ b/_incObj/18 Platforms.asm
@@ -8,11 +8,12 @@ BasicPlatform:
 		move.w	Plat_Index(pc,d0.w),d1
 		jmp	Plat_Index(pc,d1.w)
 ; ===========================================================================
-Plat_Index:	dc.w Plat_Main-Plat_Index
-		dc.w Plat_Solid-Plat_Index
-		dc.w Plat_Action2-Plat_Index
-		dc.w Plat_Delete-Plat_Index
-		dc.w Plat_Action-Plat_Index
+Plat_Index:	offsetTable
+		ptr Plat_Main
+		ptr Plat_Solid
+		ptr Plat_Action2
+		ptr Plat_Delete
+		ptr Plat_Action
 ; ===========================================================================
 
 Plat_Main:	; Routine 0

--- a/_incObj/1A Collapsing Ledge.asm
+++ b/_incObj/1A Collapsing Ledge.asm
@@ -8,12 +8,13 @@ CollapseLedge:
 		move.w	Ledge_Index(pc,d0.w),d1
 		jmp	Ledge_Index(pc,d1.w)
 ; ===========================================================================
-Ledge_Index:	dc.w Ledge_Main-Ledge_Index
-		dc.w Ledge_Touch-Ledge_Index
-		dc.w Ledge_Collapse-Ledge_Index
-		dc.w Ledge_Display-Ledge_Index
-		dc.w Ledge_Delete-Ledge_Index
-		dc.w Ledge_WalkOff-Ledge_Index
+Ledge_Index:	offsetTable
+		ptr Ledge_Main
+		ptr Ledge_Touch
+		ptr Ledge_Collapse
+		ptr Ledge_Display
+		ptr Ledge_Delete
+		ptr Ledge_WalkOff
 
 ledge_timedelay = objoff_38		; time between touching the ledge and it collapsing
 ledge_collapse_flag = objoff_3A		; collapse flag

--- a/_incObj/1B Water Surface.asm
+++ b/_incObj/1B Water Surface.asm
@@ -8,8 +8,9 @@ WaterSurface:
 		move.w	Surf_Index(pc,d0.w),d1
 		jmp	Surf_Index(pc,d1.w)
 ; ===========================================================================
-Surf_Index:	dc.w Surf_Main-Surf_Index
-		dc.w Surf_Action-Surf_Index
+Surf_Index:	offsetTable
+		ptr Surf_Main
+		ptr Surf_Action
 
 surf_origX = objoff_30		; original x-axis position
 surf_freeze = objoff_32		; flag to freeze animation

--- a/_incObj/1C Scenery.asm
+++ b/_incObj/1C Scenery.asm
@@ -8,8 +8,9 @@ Scenery:
 		move.w	Scen_Index(pc,d0.w),d1
 		jmp	Scen_Index(pc,d1.w)
 ; ===========================================================================
-Scen_Index:	dc.w Scen_Main-Scen_Index
-		dc.w Scen_ChkDel-Scen_Index
+Scen_Index:	offsetTable
+		ptr Scen_Main
+		ptr Scen_ChkDel
 ; ===========================================================================
 
 Scen_Main:	; Routine 0

--- a/_incObj/1D Unused Switch.asm
+++ b/_incObj/1D Unused Switch.asm
@@ -9,9 +9,10 @@ MagicSwitch:
 		move.w	Swi_Index(pc,d0.w),d1
 		jmp	Swi_Index(pc,d1.w)
 ; ===========================================================================
-Swi_Index:	dc.w Swi_Main-Swi_Index
-		dc.w Swi_Action-Swi_Index
-		dc.w Swi_Delete-Swi_Index
+Swi_Index:	offsetTable
+		ptr Swi_Main
+		ptr Swi_Action
+		ptr Swi_Delete
 
 swi_origY = objoff_30		; original y-axis position
 ; ===========================================================================

--- a/_incObj/1E Ball Hog.asm
+++ b/_incObj/1E Ball Hog.asm
@@ -8,8 +8,9 @@ BallHog:
 		move.w	Hog_Index(pc,d0.w),d1
 		jmp	Hog_Index(pc,d1.w)
 ; ===========================================================================
-Hog_Index:	dc.w Hog_Main-Hog_Index
-		dc.w Hog_Action-Hog_Index
+Hog_Index:	offsetTable
+		ptr Hog_Main
+		ptr Hog_Action
 
 hog_launchflag = objoff_32		; 0 to launch a cannonball
 ; ===========================================================================

--- a/_incObj/1F Crabmeat.asm
+++ b/_incObj/1F Crabmeat.asm
@@ -8,11 +8,12 @@ Crabmeat:
 		move.w	Crab_Index(pc,d0.w),d1
 		jmp	Crab_Index(pc,d1.w)
 ; ===========================================================================
-Crab_Index:	dc.w Crab_Main-Crab_Index
-		dc.w Crab_Action-Crab_Index
-		dc.w Crab_Delete-Crab_Index
-		dc.w Crab_BallMain-Crab_Index
-		dc.w Crab_BallMove-Crab_Index
+Crab_Index:	offsetTable
+		ptr Crab_Main
+		ptr Crab_Action
+		ptr Crab_Delete
+		ptr Crab_BallMain
+		ptr Crab_BallMove
 
 crab_timedelay = objoff_30
 crab_mode = objoff_32

--- a/_incObj/20 Cannonball.asm
+++ b/_incObj/20 Cannonball.asm
@@ -8,8 +8,9 @@ Cannonball:
 		move.w	Cbal_Index(pc,d0.w),d1
 		jmp	Cbal_Index(pc,d1.w)
 ; ===========================================================================
-Cbal_Index:	dc.w Cbal_Main-Cbal_Index
-		dc.w Cbal_Bounce-Cbal_Index
+Cbal_Index:	offsetTable
+		ptr Cbal_Main
+		ptr Cbal_Bounce
 
 cbal_time = objoff_30		; time until the cannonball explodes (2 bytes)
 ; ===========================================================================

--- a/_incObj/21 HUD.asm
+++ b/_incObj/21 HUD.asm
@@ -8,8 +8,9 @@ HUD:
 		move.w	HUD_Index(pc,d0.w),d1
 		jmp	HUD_Index(pc,d1.w)
 ; ===========================================================================
-HUD_Index:	dc.w HUD_Main-HUD_Index
-		dc.w HUD_Flash-HUD_Index
+HUD_Index:	offsetTable
+		ptr HUD_Main
+		ptr HUD_Flash
 ; ===========================================================================
 
 HUD_Main:	; Routine 0

--- a/_incObj/22 Buzz Bomber.asm
+++ b/_incObj/22 Buzz Bomber.asm
@@ -9,9 +9,10 @@ BuzzBomber:
 		move.w	Buzz_Index(pc,d0.w),d1
 		jmp	Buzz_Index(pc,d1.w)
 ; ===========================================================================
-Buzz_Index:	dc.w Buzz_Main-Buzz_Index
-		dc.w Buzz_Action-Buzz_Index
-		dc.w Buzz_Delete-Buzz_Index
+Buzz_Index:	offsetTable
+		ptr Buzz_Main
+		ptr Buzz_Action
+		ptr Buzz_Delete
 
 buzz_timedelay = objoff_32
 buzz_buzzstatus = objoff_34

--- a/_incObj/23 Buzz Bomber Missile.asm
+++ b/_incObj/23 Buzz Bomber Missile.asm
@@ -8,11 +8,12 @@ Missile:
 		move.w	Msl_Index(pc,d0.w),d1
 		jmp	Msl_Index(pc,d1.w)
 ; ===========================================================================
-Msl_Index:	dc.w Msl_Main-Msl_Index
-		dc.w Msl_Animate-Msl_Index
-		dc.w Msl_FromBuzz-Msl_Index
-		dc.w Msl_Delete-Msl_Index
-		dc.w Msl_FromNewt-Msl_Index
+Msl_Index:	offsetTable
+		ptr Msl_Main
+		ptr Msl_Animate
+		ptr Msl_FromBuzz
+		ptr Msl_Delete
+		ptr Msl_FromNewt
 
 msl_parent = objoff_3C
 ; ===========================================================================

--- a/_incObj/24, 27 & 3F Explosions.asm
+++ b/_incObj/24, 27 & 3F Explosions.asm
@@ -15,8 +15,9 @@ UnusedExplosion:
 		move.w	UnkExpl_Index(pc,d0.w),d1
 		jmp	UnkExpl_Index(pc,d1.w)
 ; ===========================================================================
-UnkExpl_Index:	dc.w UnkExpl_Main-UnkExpl_Index
-		dc.w UnkExpl_Animate-UnkExpl_Index
+UnkExpl_Index:	offsetTable
+		ptr UnkExpl_Main
+		ptr UnkExpl_Animate
 ; ===========================================================================
 
 UnkExpl_Main:	; Routine 0
@@ -54,9 +55,10 @@ ExplosionItem:
 		move.w	ExItem_Index(pc,d0.w),d1
 		jmp	ExItem_Index(pc,d1.w)
 ; ===========================================================================
-ExItem_Index:	dc.w ExItem_Animal-ExItem_Index
-		dc.w ExItem_Main-ExItem_Index
-		dc.w ExItem_Animate-ExItem_Index
+ExItem_Index:	offsetTable
+		ptr ExItem_Animal
+		ptr ExItem_Main
+		ptr ExItem_Animate
 ; ===========================================================================
 
 ExItem_Animal:	; Routine 0
@@ -104,8 +106,9 @@ Explosion:
 		move.w	Expl_Index(pc,d0.w),d1
 		jmp	Expl_Index(pc,d1.w)
 ; ===========================================================================
-Expl_Index:	dc.w Expl_Main-Expl_Index
-		dc.w ExItem_Animate-Expl_Index	; <-- this branches to a different object!
+Expl_Index:	offsetTable
+		ptr Expl_Main
+		ptr ExItem_Animate	; <-- this branches to a different object!
 ; ===========================================================================
 
 Expl_Main:	; Routine 0

--- a/_incObj/25 & 37 Rings.asm
+++ b/_incObj/25 & 37 Rings.asm
@@ -8,11 +8,12 @@ Rings:
 		move.w	Ring_Index(pc,d0.w),d1
 		jmp	Ring_Index(pc,d1.w)
 ; ===========================================================================
-Ring_Index:	dc.w Ring_Main-Ring_Index
-		dc.w Ring_Animate-Ring_Index
-		dc.w Ring_Collect-Ring_Index
-		dc.w Ring_Sparkle-Ring_Index
-		dc.w Ring_Delete-Ring_Index
+Ring_Index:	offsetTable
+		ptr Ring_Main
+		ptr Ring_Animate
+		ptr Ring_Collect
+		ptr Ring_Sparkle
+		ptr Ring_Delete
 ; ===========================================================================
 
 ; ---------------------------------------------------------------------------
@@ -166,11 +167,12 @@ RingLoss:
 		move.w	RLoss_Index(pc,d0.w),d1
 		jmp	RLoss_Index(pc,d1.w)
 ; ===========================================================================
-RLoss_Index:	dc.w RLoss_Count-RLoss_Index
-		dc.w RLoss_Bounce-RLoss_Index
-		dc.w RLoss_Collect-RLoss_Index
-		dc.w RLoss_Sparkle-RLoss_Index
-		dc.w RLoss_Delete-RLoss_Index
+RLoss_Index:	offsetTable
+		ptr RLoss_Count
+		ptr RLoss_Bounce
+		ptr RLoss_Collect
+		ptr RLoss_Sparkle
+		ptr RLoss_Delete
 ; ===========================================================================
 
 RLoss_Count:	; Routine 0

--- a/_incObj/26 Monitor.asm
+++ b/_incObj/26 Monitor.asm
@@ -8,11 +8,12 @@ Monitor:
 		move.w	Mon_Index(pc,d0.w),d1
 		jmp	Mon_Index(pc,d1.w)
 ; ===========================================================================
-Mon_Index:	dc.w Mon_Main-Mon_Index
-		dc.w Mon_Solid-Mon_Index
-		dc.w Mon_BreakOpen-Mon_Index
-		dc.w Mon_Animate-Mon_Index
-		dc.w Mon_Display-Mon_Index
+Mon_Index:	offsetTable
+		ptr Mon_Main
+		ptr Mon_Solid
+		ptr Mon_BreakOpen
+		ptr Mon_Animate
+		ptr Mon_Display
 ; ===========================================================================
 
 Mon_Main:	; Routine 0

--- a/_incObj/28 Animals.asm
+++ b/_incObj/28 Animals.asm
@@ -8,27 +8,28 @@ Animals:
 		move.w	Anml_Index(pc,d0.w),d1
 		jmp	Anml_Index(pc,d1.w)
 ; ===========================================================================
-Anml_Index:	dc.w Anml_Main-Anml_Index
-		dc.w Anml_ChkFloor-Anml_Index
-		dc.w Anml_Type0-Anml_Index
-		dc.w Anml_Type1-Anml_Index
-		dc.w Anml_Type0-Anml_Index
-		dc.w Anml_Type0-Anml_Index
-		dc.w Anml_Type0-Anml_Index
-		dc.w Anml_Type1-Anml_Index
-		dc.w Anml_Type0-Anml_Index
-		dc.w Anml_FromPrison-Anml_Index
-		dc.w Anml_End_0A-Anml_Index
-		dc.w Anml_End_0A-Anml_Index
-		dc.w Anml_End_0C-Anml_Index
-		dc.w Anml_End_0D-Anml_Index
-		dc.w Anml_End_0E-Anml_Index
-		dc.w Anml_End_0F-Anml_Index
-		dc.w Anml_End_0E-Anml_Index
-		dc.w Anml_End_0F-Anml_Index
-		dc.w Anml_End_0E-Anml_Index
-		dc.w Anml_End_13-Anml_Index
-		dc.w Anml_End_14-Anml_Index
+Anml_Index:	offsetTable
+		ptr Anml_Main
+		ptr Anml_ChkFloor
+		ptr Anml_Type0
+		ptr Anml_Type1
+		ptr Anml_Type0
+		ptr Anml_Type0
+		ptr Anml_Type0
+		ptr Anml_Type1
+		ptr Anml_Type0
+		ptr Anml_FromPrison
+		ptr Anml_End_0A
+		ptr Anml_End_0A
+		ptr Anml_End_0C
+		ptr Anml_End_0D
+		ptr Anml_End_0E
+		ptr Anml_End_0F
+		ptr Anml_End_0E
+		ptr Anml_End_0F
+		ptr Anml_End_0E
+		ptr Anml_End_13
+		ptr Anml_End_14
 ; ===========================================================================
 
 Anml_VarIndex:	; two index IDs for Anml_Variables

--- a/_incObj/29 Points.asm
+++ b/_incObj/29 Points.asm
@@ -9,8 +9,9 @@ Points:
 		jsr	Poi_Index(pc,d1.w)
 		bra.w	DisplaySprite
 ; ===========================================================================
-Poi_Index:	dc.w Poi_Main-Poi_Index
-		dc.w Poi_Slower-Poi_Index
+Poi_Index:	offsetTable
+		ptr Poi_Main
+		ptr Poi_Slower
 ; ===========================================================================
 
 Poi_Main:	; Routine 0

--- a/_incObj/2A SBZ Small Door.asm
+++ b/_incObj/2A SBZ Small Door.asm
@@ -8,8 +8,9 @@ AutoDoor:
 		move.w	ADoor_Index(pc,d0.w),d1
 		jmp	ADoor_Index(pc,d1.w)
 ; ===========================================================================
-ADoor_Index:	dc.w ADoor_Main-ADoor_Index
-		dc.w ADoor_OpenShut-ADoor_Index
+ADoor_Index:	offsetTable
+		ptr ADoor_Main
+		ptr ADoor_OpenShut
 ; ===========================================================================
 
 ADoor_Main:	; Routine 0

--- a/_incObj/2B Chopper.asm
+++ b/_incObj/2B Chopper.asm
@@ -9,8 +9,9 @@ Chopper:
 		jsr	Chop_Index(pc,d1.w)
 		bra.w	RememberState
 ; ===========================================================================
-Chop_Index:	dc.w Chop_Main-Chop_Index
-		dc.w Chop_ChgSpeed-Chop_Index
+Chop_Index:	offsetTable
+		ptr Chop_Main
+		ptr Chop_ChgSpeed
 
 chop_origY = objoff_30
 ; ===========================================================================

--- a/_incObj/2C Jaws.asm
+++ b/_incObj/2C Jaws.asm
@@ -8,8 +8,9 @@ Jaws:
 		move.w	Jaws_Index(pc,d0.w),d1
 		jmp	Jaws_Index(pc,d1.w)
 ; ===========================================================================
-Jaws_Index:	dc.w Jaws_Main-Jaws_Index
-		dc.w Jaws_Turn-Jaws_Index
+Jaws_Index:	offsetTable
+		ptr Jaws_Main
+		ptr Jaws_Turn
 
 jaws_timecount = objoff_30
 jaws_timedelay = objoff_32

--- a/_incObj/2D Burrobot.asm
+++ b/_incObj/2D Burrobot.asm
@@ -8,8 +8,9 @@ Burrobot:
 		move.w	Burro_Index(pc,d0.w),d1
 		jmp	Burro_Index(pc,d1.w)
 ; ===========================================================================
-Burro_Index:	dc.w Burro_Main-Burro_Index
-		dc.w Burro_Action-Burro_Index
+Burro_Index:	offsetTable
+		ptr Burro_Main
+		ptr Burro_Action
 
 burro_timedelay = objoff_30		; time between direction changes
 ; ===========================================================================

--- a/_incObj/2E Monitor Content Power-Up.asm
+++ b/_incObj/2E Monitor Content Power-Up.asm
@@ -9,9 +9,10 @@ PowerUp:
 		jsr	Pow_Index(pc,d1.w)
 		bra.w	DisplaySprite
 ; ===========================================================================
-Pow_Index:	dc.w Pow_Main-Pow_Index
-		dc.w Pow_Move-Pow_Index
-		dc.w Pow_Delete-Pow_Index
+Pow_Index:	offsetTable
+		ptr Pow_Main
+		ptr Pow_Move
+		ptr Pow_Delete
 ; ===========================================================================
 
 Pow_Main:	; Routine 0

--- a/_incObj/2F MZ Large Grassy Platforms.asm
+++ b/_incObj/2F MZ Large Grassy Platforms.asm
@@ -8,8 +8,9 @@ LargeGrass:
 		move.w	LGrass_Index(pc,d0.w),d1
 		jmp	LGrass_Index(pc,d1.w)
 ; ===========================================================================
-LGrass_Index:	dc.w LGrass_Main-LGrass_Index
-		dc.w LGrass_Action-LGrass_Index
+LGrass_Index:	offsetTable
+		ptr LGrass_Main
+		ptr LGrass_Action
 
 lgrass_origX = objoff_2A
 lgrass_origY = objoff_2C
@@ -99,12 +100,13 @@ LGrass_Types:
 ; End of function LGrass_Types
 
 ; ===========================================================================
-LGrass_TypeIndex:dc.w LGrass_Type00-LGrass_TypeIndex
-		dc.w LGrass_Type01-LGrass_TypeIndex
-		dc.w LGrass_Type02-LGrass_TypeIndex
-		dc.w LGrass_Type03-LGrass_TypeIndex
-		dc.w LGrass_Type04-LGrass_TypeIndex
-		dc.w LGrass_Type05-LGrass_TypeIndex
+LGrass_TypeIndex: offsetTable
+		ptr LGrass_Type00
+		ptr LGrass_Type01
+		ptr LGrass_Type02
+		ptr LGrass_Type03
+		ptr LGrass_Type04
+		ptr LGrass_Type05
 ; ===========================================================================
 
 LGrass_Type00:

--- a/_incObj/30 MZ Large Green Glass Blocks.asm
+++ b/_incObj/30 MZ Large Green Glass Blocks.asm
@@ -14,11 +14,12 @@ GlassBlock:
 Glass_Delete:
 		bra.w	DeleteObject
 ; ===========================================================================
-Glass_Index:	dc.w Glass_Main-Glass_Index
-		dc.w Glass_Block012-Glass_Index
-		dc.w Glass_Reflect012-Glass_Index
-		dc.w Glass_Block34-Glass_Index
-		dc.w Glass_Reflect34-Glass_Index
+Glass_Index:	offsetTable
+		ptr Glass_Main
+		ptr Glass_Block012
+		ptr Glass_Reflect012
+		ptr Glass_Block34
+		ptr Glass_Reflect34
 
 glass_dist = objoff_32		; distance block moves when switch is pressed
 glass_parent = objoff_3C		; address of parent object
@@ -120,11 +121,12 @@ Glass_Types:
 ; End of function Glass_Types
 
 ; ===========================================================================
-Glass_TypeIndex:dc.w Glass_Type00-Glass_TypeIndex
-		dc.w Glass_Type01-Glass_TypeIndex
-		dc.w Glass_Type02-Glass_TypeIndex
-		dc.w Glass_Type03-Glass_TypeIndex
-		dc.w Glass_Type04-Glass_TypeIndex
+Glass_TypeIndex: offsetTable
+		ptr Glass_Type00
+		ptr Glass_Type01
+		ptr Glass_Type02
+		ptr Glass_Type03
+		ptr Glass_Type04
 ; ===========================================================================
 
 Glass_Type00:

--- a/_incObj/31 Chained Stompers.asm
+++ b/_incObj/31 Chained Stompers.asm
@@ -8,11 +8,12 @@ ChainStomp:
 		move.w	CStom_Index(pc,d0.w),d1
 		jmp	CStom_Index(pc,d1.w)
 ; ===========================================================================
-CStom_Index:	dc.w CStom_Main-CStom_Index
-		dc.w CStom_Block-CStom_Index
-		dc.w CStom_Spikes-CStom_Index
-		dc.w CStom_Ceiling-CStom_Index
-		dc.w CStom_Chain-CStom_Index
+CStom_Index:	offsetTable
+		ptr CStom_Main
+		ptr CStom_Block
+		ptr CStom_Spikes
+		ptr CStom_Ceiling
+		ptr CStom_Chain
 
 CStom_switch = objoff_3A		; switch number for the current stomper
 
@@ -182,13 +183,14 @@ CStom_Types:
 		move.w	CStom_TypeIndex(pc,d0.w),d1
 		jmp	CStom_TypeIndex(pc,d1.w)
 ; ===========================================================================
-CStom_TypeIndex:dc.w CStom_Type00-CStom_TypeIndex
-		dc.w CStom_Type01-CStom_TypeIndex
-		dc.w CStom_Type01-CStom_TypeIndex
-		dc.w CStom_Type03-CStom_TypeIndex
-		dc.w CStom_Type01-CStom_TypeIndex
-		dc.w CStom_Type03-CStom_TypeIndex
-		dc.w CStom_Type01-CStom_TypeIndex
+CStom_TypeIndex: offsetTable
+		ptr CStom_Type00
+		ptr CStom_Type01
+		ptr CStom_Type01
+		ptr CStom_Type03
+		ptr CStom_Type01
+		ptr CStom_Type03
+		ptr CStom_Type01
 ; ===========================================================================
 
 CStom_Type00:

--- a/_incObj/32 Button.asm
+++ b/_incObj/32 Button.asm
@@ -9,8 +9,9 @@ Button:
 		move.w	But_Index(pc,d0.w),d1
 		jmp	But_Index(pc,d1.w)
 ; ===========================================================================
-But_Index:	dc.w But_Main-But_Index
-		dc.w But_Pressed-But_Index
+But_Index:	offsetTable
+		ptr But_Main
+		ptr But_Pressed
 ; ===========================================================================
 
 But_Main:	; Routine 0

--- a/_incObj/33 Pushable Blocks.asm
+++ b/_incObj/33 Pushable Blocks.asm
@@ -8,9 +8,10 @@ PushBlock:
 		move.w	PushB_Index(pc,d0.w),d1
 		jmp	PushB_Index(pc,d1.w)
 ; ===========================================================================
-PushB_Index:	dc.w PushB_Main-PushB_Index
-		dc.w PushB_Action-PushB_Index
-		dc.w PushB_ChkVisible-PushB_Index
+PushB_Index:	offsetTable
+		ptr PushB_Main
+		ptr PushB_Action
+		ptr PushB_ChkVisible
 
 PushB_Var:	dc.b $10, 0	; object width, frame number
 		dc.b $40, 1

--- a/_incObj/34 Title Cards.asm
+++ b/_incObj/34 Title Cards.asm
@@ -8,10 +8,11 @@ TitleCard:
 		move.w	Card_Index(pc,d0.w),d1
 		jmp	Card_Index(pc,d1.w)
 ; ===========================================================================
-Card_Index:	dc.w Card_CheckSBZ3-Card_Index
-		dc.w Card_ChkPos-Card_Index
-		dc.w Card_Wait-Card_Index
-		dc.w Card_Wait-Card_Index
+Card_Index:	offsetTable
+		ptr Card_CheckSBZ3
+		ptr Card_ChkPos
+		ptr Card_Wait
+		ptr Card_Wait
 
 card_mainX:	equ	objoff_30		; position for card to display on
 card_finalX:	equ	objoff_32		; position for card to finish on

--- a/_incObj/35 Burning Grass.asm
+++ b/_incObj/35 Burning Grass.asm
@@ -9,9 +9,10 @@ GrassFire:
 		move.w	GFire_Index(pc,d0.w),d1
 		jmp	GFire_Index(pc,d1.w)
 ; ===========================================================================
-GFire_Index:	dc.w GFire_Main-GFire_Index
-		dc.w GFire_Spread-GFire_Index
-		dc.w GFire_Move-GFire_Index
+GFire_Index:	offsetTable
+		ptr GFire_Main
+		ptr GFire_Spread
+		ptr GFire_Move
 
 gfire_origX = objoff_2A
 ; ===========================================================================

--- a/_incObj/36 Spikes.asm
+++ b/_incObj/36 Spikes.asm
@@ -8,8 +8,9 @@ Spikes:
 		move.w	Spik_Index(pc,d0.w),d1
 		jmp	Spik_Index(pc,d1.w)
 ; ===========================================================================
-Spik_Index:	dc.w Spik_Main-Spik_Index
-		dc.w Spik_Solid-Spik_Index
+Spik_Index:	offsetTable
+		ptr Spik_Main
+		ptr Spik_Solid
 
 spik_origX equ objoff_30		; start X position
 spik_origY equ objoff_32		; start Y position
@@ -160,9 +161,10 @@ Spik_Type0x:
 		move.w	Spik_TypeIndex(pc,d0.w),d1
 		jmp	Spik_TypeIndex(pc,d1.w)
 ; ===========================================================================
-Spik_TypeIndex:	dc.w Spik_Type00-Spik_TypeIndex
-		dc.w Spik_Type01-Spik_TypeIndex
-		dc.w Spik_Type02-Spik_TypeIndex
+Spik_TypeIndex:	offsetTable
+		ptr Spik_Type00
+		ptr Spik_Type01
+		ptr Spik_Type02
 ; ===========================================================================
 
 Spik_Type00:

--- a/_incObj/38 Shield and Invincibility.asm
+++ b/_incObj/38 Shield and Invincibility.asm
@@ -8,9 +8,10 @@ ShieldItem:
 		move.w	Shi_Index(pc,d0.w),d1
 		jmp	Shi_Index(pc,d1.w)
 ; ===========================================================================
-Shi_Index:	dc.w Shi_Main-Shi_Index
-		dc.w Shi_Shield-Shi_Index
-		dc.w Shi_Stars-Shi_Index
+Shi_Index:	offsetTable
+		ptr Shi_Main
+		ptr Shi_Shield
+		ptr Shi_Stars
 ; ===========================================================================
 
 Shi_Main:	; Routine 0

--- a/_incObj/39 Game Over.asm
+++ b/_incObj/39 Game Over.asm
@@ -8,9 +8,10 @@ GameOverCard:
 		move.w	Over_Index(pc,d0.w),d1
 		jmp	Over_Index(pc,d1.w)
 ; ===========================================================================
-Over_Index:	dc.w Over_ChkPLC-Over_Index
-		dc.w Over_Move-Over_Index
-		dc.w Over_Wait-Over_Index
+Over_Index:	offsetTable
+		ptr Over_ChkPLC
+		ptr Over_Move
+		ptr Over_Wait
 ; ===========================================================================
 
 Over_ChkPLC:	; Routine 0

--- a/_incObj/3A Got Through Card.asm
+++ b/_incObj/3A Got Through Card.asm
@@ -8,15 +8,16 @@ GotThroughCard:
 		move.w	Got_Index(pc,d0.w),d1
 		jmp	Got_Index(pc,d1.w)
 ; ===========================================================================
-Got_Index:	dc.w Got_ChkPLC-Got_Index
-		dc.w Got_Move-Got_Index
-		dc.w Got_Wait-Got_Index
-		dc.w Got_Bonus-Got_Index
-		dc.w Got_Wait-Got_Index
-		dc.w Got_NextLevel-Got_Index
-		dc.w Got_Wait-Got_Index
-		dc.w Got_MoveBack-Got_Index
-		dc.w Got_Boundary-Got_Index
+Got_Index:	offsetTable
+		ptr Got_ChkPLC
+		ptr Got_Move
+		ptr Got_Wait
+		ptr Got_Bonus
+		ptr Got_Wait
+		ptr Got_NextLevel
+		ptr Got_Wait
+		ptr Got_MoveBack
+		ptr Got_Boundary
 
 got_mainX = objoff_30		; position for card to display on
 got_finalX = objoff_32		; position for card to finish on

--- a/_incObj/3B Purple Rock.asm
+++ b/_incObj/3B Purple Rock.asm
@@ -8,8 +8,9 @@ PurpleRock:
 		move.w	Rock_Index(pc,d0.w),d1
 		jmp	Rock_Index(pc,d1.w)
 ; ===========================================================================
-Rock_Index:	dc.w Rock_Main-Rock_Index
-		dc.w Rock_Solid-Rock_Index
+Rock_Index:	offsetTable
+		ptr Rock_Main
+		ptr Rock_Solid
 ; ===========================================================================
 
 Rock_Main:	; Routine 0

--- a/_incObj/3C Smashable Wall.asm
+++ b/_incObj/3C Smashable Wall.asm
@@ -9,9 +9,10 @@ SmashWall:
 		jsr	Smash_Index(pc,d1.w)
 		bra.w	RememberState
 ; ===========================================================================
-Smash_Index:	dc.w Smash_Main-Smash_Index
-		dc.w Smash_Solid-Smash_Index
-		dc.w Smash_FragMove-Smash_Index
+Smash_Index:	offsetTable
+		ptr Smash_Main
+		ptr Smash_Solid
+		ptr Smash_FragMove
 
 smash_speed = objoff_30		; Sonic's horizontal speed
 ; ===========================================================================

--- a/_incObj/3D Boss - Green Hill.asm
+++ b/_incObj/3D Boss - Green Hill.asm
@@ -8,10 +8,11 @@ BossGreenHill:
 		move.w	BGHZ_Index(pc,d0.w),d1
 		jmp	BGHZ_Index(pc,d1.w)
 ; ===========================================================================
-BGHZ_Index:	dc.w BGHZ_Main-BGHZ_Index
-		dc.w BGHZ_ShipMain-BGHZ_Index
-		dc.w BGHZ_FaceMain-BGHZ_Index
-		dc.w BGHZ_FlameMain-BGHZ_Index
+BGHZ_Index:	offsetTable
+		ptr BGHZ_Main
+		ptr BGHZ_ShipMain
+		ptr BGHZ_FaceMain
+		ptr BGHZ_FlameMain
 
 BGHZ_ObjData:	dc.b 2,	0		; routine counter, animation
 		dc.b 4,	1
@@ -62,13 +63,14 @@ BGHZ_ShipMain:	; Routine 2
 		or.b	d0,obRender(a0)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-BGHZ_ShipIndex:	dc.w BGHZ_ShipStart-BGHZ_ShipIndex
-		dc.w BGHZ_MakeBall-BGHZ_ShipIndex
-		dc.w BGHZ_ShipMove-BGHZ_ShipIndex
-		dc.w BGHZ_ChgDir-BGHZ_ShipIndex
-		dc.w BGHZ_Explode-BGHZ_ShipIndex
-		dc.w BGHZ_Recover-BGHZ_ShipIndex
-		dc.w BGHZ_Escape-BGHZ_ShipIndex
+BGHZ_ShipIndex:	offsetTable
+		ptr BGHZ_ShipStart
+		ptr BGHZ_MakeBall
+		ptr BGHZ_ShipMove
+		ptr BGHZ_ChgDir
+		ptr BGHZ_Explode
+		ptr BGHZ_Recover
+		ptr BGHZ_Escape
 ; ===========================================================================
 
 BGHZ_ShipStart:

--- a/_incObj/3E Prison Capsule.asm
+++ b/_incObj/3E Prison Capsule.asm
@@ -13,14 +13,15 @@ Prison:
 .delete:
 		jmp	(DeleteObject).l
 ; ===========================================================================
-Pri_Index:	dc.w Pri_Main-Pri_Index
-		dc.w Pri_BodyMain-Pri_Index
-		dc.w Pri_Switched-Pri_Index
-		dc.w Pri_Explosion-Pri_Index
-		dc.w Pri_Explosion-Pri_Index
-		dc.w Pri_Explosion-Pri_Index
-		dc.w Pri_Animals-Pri_Index
-		dc.w Pri_EndAct-Pri_Index
+Pri_Index:	offsetTable
+		ptr Pri_Main
+		ptr Pri_BodyMain
+		ptr Pri_Switched
+		ptr Pri_Explosion
+		ptr Pri_Explosion
+		ptr Pri_Explosion
+		ptr Pri_Animals
+		ptr Pri_EndAct
 
 pri_origY = objoff_30		; original y-axis position
 

--- a/_incObj/40 Moto Bug.asm
+++ b/_incObj/40 Moto Bug.asm
@@ -8,10 +8,11 @@ MotoBug:
 		move.w	Moto_Index(pc,d0.w),d1
 		jmp	Moto_Index(pc,d1.w)
 ; ===========================================================================
-Moto_Index:	dc.w Moto_Main-Moto_Index
-		dc.w Moto_Action-Moto_Index
-		dc.w Moto_Animate-Moto_Index
-		dc.w Moto_Delete-Moto_Index
+Moto_Index:	offsetTable
+		ptr Moto_Main
+		ptr Moto_Action
+		ptr Moto_Animate
+		ptr Moto_Delete
 ; ===========================================================================
 
 Moto_Main:	; Routine 0
@@ -54,8 +55,9 @@ Moto_Action:	; Routine 2
 		include	"_incObj/sub RememberState.asm" ; Moto_Action terminates in this file
 
 ; ===========================================================================
-Moto_ActIndex:	dc.w .move-Moto_ActIndex
-		dc.w .findfloor-Moto_ActIndex
+Moto_ActIndex:	offsetTable
+		ptr .move
+		ptr .findfloor
 
 .time = objoff_30
 .smokedelay = objoff_33

--- a/_incObj/41 Springs.asm
+++ b/_incObj/41 Springs.asm
@@ -11,16 +11,17 @@ Springs:
 		out_of_range.w	DeleteObject
 		rts
 ; ===========================================================================
-Spring_Index:	dc.w Spring_Main-Spring_Index
-		dc.w Spring_Up-Spring_Index
-		dc.w Spring_AniUp-Spring_Index
-		dc.w Spring_ResetUp-Spring_Index
-		dc.w Spring_LR-Spring_Index
-		dc.w Spring_AniLR-Spring_Index
-		dc.w Spring_ResetLR-Spring_Index
-		dc.w Spring_Dwn-Spring_Index
-		dc.w Spring_AniDwn-Spring_Index
-		dc.w Spring_ResetDwn-Spring_Index
+Spring_Index:	offsetTable
+		ptr Spring_Main
+		ptr Spring_Up
+		ptr Spring_AniUp
+		ptr Spring_ResetUp
+		ptr Spring_LR
+		ptr Spring_AniLR
+		ptr Spring_ResetLR
+		ptr Spring_Dwn
+		ptr Spring_AniDwn
+		ptr Spring_ResetDwn
 
 spring_pow = objoff_30			; power of current spring
 

--- a/_incObj/42 Newtron.asm
+++ b/_incObj/42 Newtron.asm
@@ -8,9 +8,10 @@ Newtron:
 		move.w	Newt_Index(pc,d0.w),d1
 		jmp	Newt_Index(pc,d1.w)
 ; ===========================================================================
-Newt_Index:	dc.w Newt_Main-Newt_Index
-		dc.w Newt_Action-Newt_Index
-		dc.w Newt_Delete-Newt_Index
+Newt_Index:	offsetTable
+		ptr Newt_Main
+		ptr Newt_Action
+		ptr Newt_Delete
 ; ===========================================================================
 
 Newt_Main:	; Routine 0

--- a/_incObj/43 Roller.asm
+++ b/_incObj/43 Roller.asm
@@ -8,8 +8,9 @@ Roller:
 		move.w	Roll_Index(pc,d0.w),d1
 		jmp	Roll_Index(pc,d1.w)
 ; ===========================================================================
-Roll_Index:	dc.w Roll_Main-Roll_Index
-		dc.w Roll_Action-Roll_Index
+Roll_Index:	offsetTable
+		ptr Roll_Main
+		ptr Roll_Action
 ; ===========================================================================
 
 Roll_Main:	; Routine 0
@@ -60,10 +61,11 @@ Roll_ChkGone:
 Roll_Delete:
 		bra.w	DeleteObject
 ; ===========================================================================
-Roll_Index2:	dc.w Roll_RollChk-Roll_Index2
-		dc.w Roll_RollNoChk-Roll_Index2
-		dc.w Roll_ChkJump-Roll_Index2
-		dc.w Roll_MatchFloor-Roll_Index2
+Roll_Index2:	offsetTable
+		ptr Roll_RollChk
+		ptr Roll_RollNoChk
+		ptr Roll_ChkJump
+		ptr Roll_MatchFloor
 ; ===========================================================================
 
 Roll_RollChk:

--- a/_incObj/44 GHZ Edge Walls (part 1).asm
+++ b/_incObj/44 GHZ Edge Walls (part 1).asm
@@ -8,9 +8,10 @@ EdgeWalls:
 		move.w	Edge_Index(pc,d0.w),d1
 		jmp	Edge_Index(pc,d1.w)
 ; ===========================================================================
-Edge_Index:	dc.w Edge_Main-Edge_Index
-		dc.w Edge_Solid-Edge_Index
-		dc.w Edge_Display-Edge_Index
+Edge_Index:	offsetTable
+		ptr Edge_Main
+		ptr Edge_Solid
+		ptr Edge_Display
 ; ===========================================================================
 
 Edge_Main:	; Routine 0

--- a/_incObj/45 Sideways Stomper.asm
+++ b/_incObj/45 Sideways Stomper.asm
@@ -8,11 +8,12 @@ SideStomp:
 		move.w	SStom_Index(pc,d0.w),d1
 		jmp	SStom_Index(pc,d1.w)
 ; ===========================================================================
-SStom_Index:	dc.w SStom_Main-SStom_Index
-		dc.w SStom_Solid-SStom_Index
-		dc.w SStom_Spikes-SStom_Index
-		dc.w SStom_Display-SStom_Index
-		dc.w SStom_Pole-SStom_Index
+SStom_Index:	offsetTable
+		ptr SStom_Main
+		ptr SStom_Solid
+		ptr SStom_Spikes
+		ptr SStom_Display
+		ptr SStom_Pole
 
 		;	routine		frame
 		;		 xpos
@@ -118,12 +119,12 @@ SStom_Move:
 ; End of function SStom_Move
 
 ; ===========================================================================
-SStom_Move_Index:
-		dc.w SStom_Move_0-SStom_Move_Index	; 0
-		dc.w SStom_Move_0-SStom_Move_Index	; 1 - same as 0
+SStom_Move_Index: offsetTable
+		ptr SStom_Move_0	; 0
+		ptr SStom_Move_0	; 1 - same as 0
 	if FixBugs
 		; An entry for subtype 02 is missing, despite being defined in SStom_Len
-		dc.w SStom_Move_0-SStom_Move_Index	; 2 - missing
+		ptr SStom_Move_0	; 2 - missing
 	endif
 ; ===========================================================================
 

--- a/_incObj/46 MZ Bricks.asm
+++ b/_incObj/46 MZ Bricks.asm
@@ -8,8 +8,9 @@ MarbleBrick:
 		move.w	Brick_Index(pc,d0.w),d1
 		jmp	Brick_Index(pc,d1.w)
 ; ===========================================================================
-Brick_Index:	dc.w Brick_Main-Brick_Index
-		dc.w Brick_Action-Brick_Index
+Brick_Index:	offsetTable
+		ptr Brick_Main
+		ptr Brick_Action
 
 brick_origY = objoff_30
 ; ===========================================================================
@@ -51,11 +52,12 @@ Brick_Action:	; Routine 2
 		bra.w	DisplaySprite
 	endif
 ; ===========================================================================
-Brick_TypeIndex:dc.w Brick_Type00-Brick_TypeIndex
-		dc.w Brick_Type01-Brick_TypeIndex
-		dc.w Brick_Type02-Brick_TypeIndex
-		dc.w Brick_Type03-Brick_TypeIndex
-		dc.w Brick_Type04-Brick_TypeIndex
+Brick_TypeIndex: offsetTable
+		ptr Brick_Type00
+		ptr Brick_Type01
+		ptr Brick_Type02
+		ptr Brick_Type03
+		ptr Brick_Type04
 ; ===========================================================================
 
 Brick_Type00:

--- a/_incObj/47 Bumper.asm
+++ b/_incObj/47 Bumper.asm
@@ -8,8 +8,9 @@ Bumper:
 		move.w	Bump_Index(pc,d0.w),d1
 		jmp	Bump_Index(pc,d1.w)
 ; ===========================================================================
-Bump_Index:	dc.w Bump_Main-Bump_Index
-		dc.w Bump_Hit-Bump_Index
+Bump_Index:	offsetTable
+		ptr Bump_Main
+		ptr Bump_Hit
 ; ===========================================================================
 
 Bump_Main:	; Routine 0

--- a/_incObj/48 Eggman's Swinging Ball.asm
+++ b/_incObj/48 Eggman's Swinging Ball.asm
@@ -8,11 +8,12 @@ BossBall:
 		move.w	GBall_Index(pc,d0.w),d1
 		jmp	GBall_Index(pc,d1.w)
 ; ===========================================================================
-GBall_Index:	dc.w GBall_Main-GBall_Index
-		dc.w GBall_Base-GBall_Index
-		dc.w GBall_Base2-GBall_Index
-		dc.w GBall_Link-GBall_Index
-		dc.w GBall_Ball-GBall_Index
+GBall_Index:	offsetTable
+		ptr GBall_Main
+		ptr GBall_Base
+		ptr GBall_Base2
+		ptr GBall_Link
+		ptr GBall_Ball
 ; ===========================================================================
 
 GBall_Main:	; Routine 0

--- a/_incObj/49 Waterfall Sound.asm
+++ b/_incObj/49 Waterfall Sound.asm
@@ -8,8 +8,9 @@ WaterSound:
 		move.w	WSnd_Index(pc,d0.w),d1
 		jmp	WSnd_Index(pc,d1.w)
 ; ===========================================================================
-WSnd_Index:	dc.w WSnd_Main-WSnd_Index
-		dc.w WSnd_PlaySnd-WSnd_Index
+WSnd_Index:	offsetTable
+		ptr WSnd_Main
+		ptr WSnd_PlaySnd
 ; ===========================================================================
 
 WSnd_Main:	; Routine 0

--- a/_incObj/4A Special Stage Entry (Unused).asm
+++ b/_incObj/4A Special Stage Entry (Unused).asm
@@ -8,9 +8,10 @@ VanishSonic:
 		move.w	Van_Index(pc,d0.w),d1
 		jmp	Van_Index(pc,d1.w)
 ; ===========================================================================
-Van_Index:	dc.w Van_Main-Van_Index
-		dc.w Van_RmvSonic-Van_Index
-		dc.w Van_LoadSonic-Van_Index
+Van_Index:	offsetTable
+		ptr Van_Main
+		ptr Van_RmvSonic
+		ptr Van_LoadSonic
 
 van_time = objoff_30		; time for Sonic to disappear
 ; ===========================================================================

--- a/_incObj/4B Giant Ring.asm
+++ b/_incObj/4B Giant Ring.asm
@@ -8,10 +8,11 @@ GiantRing:
 		move.w	GRing_Index(pc,d0.w),d1
 		jmp	GRing_Index(pc,d1.w)
 ; ===========================================================================
-GRing_Index:	dc.w GRing_Main-GRing_Index
-		dc.w GRing_Animate-GRing_Index
-		dc.w GRing_Collect-GRing_Index
-		dc.w GRing_Delete-GRing_Index
+GRing_Index:	offsetTable
+		ptr GRing_Main
+		ptr GRing_Animate
+		ptr GRing_Collect
+		ptr GRing_Delete
 ; ===========================================================================
 
 GRing_Main:	; Routine 0

--- a/_incObj/4C & 4D Lava Geyser Maker.asm
+++ b/_incObj/4C & 4D Lava Geyser Maker.asm
@@ -15,12 +15,13 @@ GeyserMaker:
 		bra.w	Geyser_ChkDel
 	endif
 ; ===========================================================================
-GMake_Index:	dc.w GMake_Main-GMake_Index
-		dc.w GMake_Wait-GMake_Index
-		dc.w GMake_ChkType-GMake_Index
-		dc.w GMake_MakeLava-GMake_Index
-		dc.w GMake_Display-GMake_Index
-		dc.w GMake_Delete-GMake_Index
+GMake_Index:	offsetTable
+		ptr GMake_Main
+		ptr GMake_Wait
+		ptr GMake_ChkType
+		ptr GMake_MakeLava
+		ptr GMake_Display
+		ptr GMake_Delete
 
 gmake_time = objoff_34		; time delay (2 bytes)
 gmake_timer = objoff_32		; current time remaining (2 bytes)
@@ -138,10 +139,11 @@ LavaGeyser:
 		bra.w	DisplaySprite
 	endif
 ; ===========================================================================
-Geyser_Index:	dc.w Geyser_Main-Geyser_Index
-		dc.w Geyser_Action-Geyser_Index
-		dc.w Geyser_Middle-Geyser_Index
-		dc.w Geyser_Delete-Geyser_Index
+Geyser_Index:	offsetTable
+		ptr Geyser_Main
+		ptr Geyser_Action
+		ptr Geyser_Middle
+		ptr Geyser_Delete
 
 Geyser_Speeds:	dc.w $FB00, 0
 ; ===========================================================================
@@ -232,8 +234,9 @@ Geyser_ChkDel:
 		rts
 	endif
 ; ===========================================================================
-Geyser_Types:	dc.w Geyser_Type00-Geyser_Types
-		dc.w Geyser_Type01-Geyser_Types
+Geyser_Types:	offsetTable
+		ptr Geyser_Type00
+		ptr Geyser_Type01
 ; ===========================================================================
 
 Geyser_Type00:

--- a/_incObj/4E Wall of Lava.asm
+++ b/_incObj/4E Wall of Lava.asm
@@ -8,11 +8,12 @@ LavaWall:
 		move.w	LWall_Index(pc,d0.w),d1
 		jmp	LWall_Index(pc,d1.w)
 ; ===========================================================================
-LWall_Index:	dc.w LWall_Main-LWall_Index
-		dc.w LWall_Solid-LWall_Index
-		dc.w LWall_Action-LWall_Index
-		dc.w LWall_Move-LWall_Index
-		dc.w LWall_Delete-LWall_Index
+LWall_Index:	offsetTable
+		ptr LWall_Main
+		ptr LWall_Solid
+		ptr LWall_Action
+		ptr LWall_Move
+		ptr LWall_Delete
 
 lwall_flag = objoff_36		; flag to start wall moving
 ; ===========================================================================

--- a/_incObj/50 Yadrin.asm
+++ b/_incObj/50 Yadrin.asm
@@ -46,8 +46,9 @@ Yadrin:
 		move.w	Yad_Index(pc,d0.w),d1
 		jmp	Yad_Index(pc,d1.w)
 ; ===========================================================================
-Yad_Index:	dc.w Yad_Main-Yad_Index
-		dc.w Yad_Action-Yad_Index
+Yad_Index:	offsetTable
+		ptr Yad_Main
+		ptr Yad_Action
 
 yad_timedelay = objoff_30
 ; ===========================================================================
@@ -83,8 +84,9 @@ Yad_Action:	; Routine 2
 		bsr.w	AnimateSprite
 		bra.w	RememberState
 ; ===========================================================================
-Yad_Index2:	dc.w Yad_Move-Yad_Index2
-		dc.w Yad_FixToFloor-Yad_Index2
+Yad_Index2:	offsetTable
+		ptr Yad_Move
+		ptr Yad_FixToFloor
 ; ===========================================================================
 
 Yad_Move:

--- a/_incObj/51 Smashable Green Block.asm
+++ b/_incObj/51 Smashable Green Block.asm
@@ -9,9 +9,10 @@ SmashBlock:
 		jsr	Smab_Index(pc,d1.w)
 		bra.w	RememberState
 ; ===========================================================================
-Smab_Index:	dc.w Smab_Main-Smab_Index
-		dc.w Smab_Solid-Smab_Index
-		dc.w Smab_Points-Smab_Index
+Smab_Index:	offsetTable
+		ptr Smab_Main
+		ptr Smab_Solid
+		ptr Smab_Points
 ; ===========================================================================
 
 Smab_Main:	; Routine 0

--- a/_incObj/52 Moving Blocks.asm
+++ b/_incObj/52 Moving Blocks.asm
@@ -8,9 +8,10 @@ MovingBlock:
 		move.w	MBlock_Index(pc,d0.w),d1
 		jmp	MBlock_Index(pc,d1.w)
 ; ===========================================================================
-MBlock_Index:	dc.w MBlock_Main-MBlock_Index
-		dc.w MBlock_Platform-MBlock_Index
-		dc.w MBlock_StandOn-MBlock_Index
+MBlock_Index:	offsetTable
+		ptr MBlock_Main
+		ptr MBlock_Platform
+		ptr MBlock_StandOn
 
 mblock_origX = objoff_30
 mblock_origY = objoff_32
@@ -95,18 +96,18 @@ MBlock_Move:
 		move.w	MBlock_TypeIndex(pc,d0.w),d1
 		jmp	MBlock_TypeIndex(pc,d1.w)
 ; ===========================================================================
-MBlock_TypeIndex:
-		dc.w MBlock_Type00-MBlock_TypeIndex
-		dc.w MBlock_Type01-MBlock_TypeIndex
-		dc.w MBlock_Type02-MBlock_TypeIndex
-		dc.w MBlock_Type03-MBlock_TypeIndex
-		dc.w MBlock_Type02-MBlock_TypeIndex
-		dc.w MBlock_Type05-MBlock_TypeIndex
-		dc.w MBlock_Type06-MBlock_TypeIndex
-		dc.w MBlock_Type07-MBlock_TypeIndex
-		dc.w MBlock_Type08-MBlock_TypeIndex
-		dc.w MBlock_Type02-MBlock_TypeIndex
-		dc.w MBlock_Type0A-MBlock_TypeIndex
+MBlock_TypeIndex: offsetTable
+		ptr MBlock_Type00
+		ptr MBlock_Type01
+		ptr MBlock_Type02
+		ptr MBlock_Type03
+		ptr MBlock_Type02
+		ptr MBlock_Type05
+		ptr MBlock_Type06
+		ptr MBlock_Type07
+		ptr MBlock_Type08
+		ptr MBlock_Type02
+		ptr MBlock_Type0A
 ; ===========================================================================
 
 MBlock_Type00:

--- a/_incObj/53 Collapsing Floors.asm
+++ b/_incObj/53 Collapsing Floors.asm
@@ -8,12 +8,13 @@ CollapseFloor:
 		move.w	CFlo_Index(pc,d0.w),d1
 		jmp	CFlo_Index(pc,d1.w)
 ; ===========================================================================
-CFlo_Index:	dc.w CFlo_Main-CFlo_Index
-		dc.w CFlo_Touch-CFlo_Index
-		dc.w CFlo_Collapse-CFlo_Index
-		dc.w CFlo_Display-CFlo_Index
-		dc.w CFlo_Delete-CFlo_Index
-		dc.w CFlo_WalkOff-CFlo_Index
+CFlo_Index:	offsetTable
+		ptr CFlo_Main
+		ptr CFlo_Touch
+		ptr CFlo_Collapse
+		ptr CFlo_Display
+		ptr CFlo_Delete
+		ptr CFlo_WalkOff
 
 cflo_timedelay = objoff_38
 cflo_collapse_flag = objoff_3A

--- a/_incObj/54 Lava Tag.asm
+++ b/_incObj/54 Lava Tag.asm
@@ -8,8 +8,9 @@ LavaTag:
 		move.w	LTag_Index(pc,d0.w),d1
 		jmp	LTag_Index(pc,d1.w)
 ; ===========================================================================
-LTag_Index:	dc.w LTag_Main-LTag_Index
-		dc.w LTag_ChkDel-LTag_Index
+LTag_Index:	offsetTable
+		ptr LTag_Main
+		ptr LTag_ChkDel
 
 LTag_ColTypes:	dc.b $96, $94, $95
 		even

--- a/_incObj/55 Basaran.asm
+++ b/_incObj/55 Basaran.asm
@@ -8,8 +8,9 @@ Basaran:
 		move.w	Bas_Index(pc,d0.w),d1
 		jmp	Bas_Index(pc,d1.w)
 ; ===========================================================================
-Bas_Index:	dc.w Bas_Main-Bas_Index
-		dc.w Bas_Action-Bas_Index
+Bas_Index:	offsetTable
+		ptr Bas_Main
+		ptr Bas_Action
 ; ===========================================================================
 
 Bas_Main:	; Routine 0

--- a/_incObj/56 Floating Blocks and Doors.asm
+++ b/_incObj/56 Floating Blocks and Doors.asm
@@ -8,8 +8,9 @@ FloatingBlock:
 		move.w	FBlock_Index(pc,d0.w),d1
 		jmp	FBlock_Index(pc,d1.w)
 ; ===========================================================================
-FBlock_Index:	dc.w FBlock_Main-FBlock_Index
-		dc.w FBlock_Action-FBlock_Index
+FBlock_Index:	offsetTable
+		ptr FBlock_Main
+		ptr FBlock_Action
 
 fb_origX = objoff_34		; original x-axis position
 fb_origY = objoff_30		; original y-axis position

--- a/_incObj/57 Spiked Ball and Chain.asm
+++ b/_incObj/57 Spiked Ball and Chain.asm
@@ -8,9 +8,10 @@ SpikeBall:
 		move.w	SBall_Index(pc,d0.w),d1
 		jmp	SBall_Index(pc,d1.w)
 ; ===========================================================================
-SBall_Index:	dc.w SBall_Main-SBall_Index
-		dc.w SBall_Move-SBall_Index
-		dc.w SBall_Display-SBall_Index
+SBall_Index:	offsetTable
+		ptr SBall_Main
+		ptr SBall_Move
+		ptr SBall_Display
 
 sball_childs = objoff_29	; number of child objects (1 byte)
 		; $30-$37	; object RAM numbers of childs (1 byte each)

--- a/_incObj/58 Big Spiked Ball.asm
+++ b/_incObj/58 Big Spiked Ball.asm
@@ -8,8 +8,9 @@ BigSpikeBall:
 		move.w	BBall_Index(pc,d0.w),d1
 		jmp	BBall_Index(pc,d1.w)
 ; ===========================================================================
-BBall_Index:	dc.w BBall_Main-BBall_Index
-		dc.w BBall_Move-BBall_Index
+BBall_Index:	offsetTable
+		ptr BBall_Main
+		ptr BBall_Move
 
 bball_origX = objoff_3A		; original x-axis position
 bball_origY = objoff_38		; original y-axis position

--- a/_incObj/59 SLZ Elevators.asm
+++ b/_incObj/59 SLZ Elevators.asm
@@ -14,10 +14,11 @@ Elevator:
 		out_of_range.w	DeleteObject,elev_origX(a0)
 		bra.w	DisplaySprite
 ; ===========================================================================
-Elev_Index:	dc.w Elev_Main-Elev_Index
-		dc.w Elev_Platform-Elev_Index
-		dc.w Elev_Action-Elev_Index
-		dc.w Elev_MakeMulti-Elev_Index
+Elev_Index:	offsetTable
+		ptr Elev_Main
+		ptr Elev_Platform
+		ptr Elev_Action
+		ptr Elev_MakeMulti
 
 Elev_Var1:	dc.b $28, 0		; width, frame number
 

--- a/_incObj/5A SLZ Circling Platform.asm
+++ b/_incObj/5A SLZ Circling Platform.asm
@@ -13,9 +13,10 @@ CirclingPlatform:
 		out_of_range.w	DeleteObject,circ_origX(a0)
 		bra.w	DisplaySprite
 ; ===========================================================================
-Circ_Index:	dc.w Circ_Main-Circ_Index
-		dc.w Circ_Platform-Circ_Index
-		dc.w Circ_Action-Circ_Index
+Circ_Index:	offsetTable
+		ptr Circ_Main
+		ptr Circ_Platform
+		ptr Circ_Action
 ; ===========================================================================
 
 Circ_Main:	; Routine 0

--- a/_incObj/5B Staircase.asm
+++ b/_incObj/5B Staircase.asm
@@ -15,9 +15,10 @@ Staircase:
 		out_of_range.w	DeleteObject,stair_origX(a0)
 		bra.w	DisplaySprite
 ; ===========================================================================
-Stair_Index:	dc.w Stair_Main-Stair_Index
-		dc.w Stair_Move-Stair_Index
-		dc.w Stair_Solid-Stair_Index
+Stair_Index:	offsetTable
+		ptr Stair_Main
+		ptr Stair_Move
+		ptr Stair_Solid
 ; ===========================================================================
 
 Stair_Main:	; Routine 0
@@ -95,10 +96,11 @@ loc_10F92:
 locret_10FA0:
 		rts
 ; ===========================================================================
-Stair_TypeIndex:dc.w Stair_Type00-Stair_TypeIndex
-		dc.w Stair_Type01-Stair_TypeIndex
-		dc.w Stair_Type02-Stair_TypeIndex
-		dc.w Stair_Type01-Stair_TypeIndex
+Stair_TypeIndex: offsetTable
+		ptr Stair_Type00
+		ptr Stair_Type01
+		ptr Stair_Type02
+		ptr Stair_Type01
 ; ===========================================================================
 
 Stair_Type00:

--- a/_incObj/5C Pylon.asm
+++ b/_incObj/5C Pylon.asm
@@ -8,8 +8,9 @@ Pylon:
 		move.w	Pyl_Index(pc,d0.w),d1
 		jmp	Pyl_Index(pc,d1.w)
 ; ===========================================================================
-Pyl_Index:	dc.w Pyl_Main-Pyl_Index
-		dc.w Pyl_Display-Pyl_Index
+Pyl_Index:	offsetTable
+		ptr Pyl_Main
+		ptr Pyl_Display
 ; ===========================================================================
 
 Pyl_Main:	; Routine 0

--- a/_incObj/5D Fan.asm
+++ b/_incObj/5D Fan.asm
@@ -8,8 +8,9 @@ Fan:
 		move.w	Fan_Index(pc,d0.w),d1
 		jmp	Fan_Index(pc,d1.w)
 ; ===========================================================================
-Fan_Index:	dc.w Fan_Main-Fan_Index
-		dc.w Fan_Delay-Fan_Index
+Fan_Index:	offsetTable
+		ptr Fan_Main
+		ptr Fan_Delay
 
 fan_time = objoff_30		; time between switching on/off
 fan_switch = objoff_32		; on/off switch

--- a/_incObj/5E Seesaw.asm
+++ b/_incObj/5E Seesaw.asm
@@ -24,12 +24,13 @@ Seesaw:
 		bhi.w	DeleteObject
 		bra.w	DisplaySprite
 ; ===========================================================================
-See_Index:	dc.w See_Main-See_Index
-		dc.w See_Slope-See_Index
-		dc.w See_Slope2-See_Index
-		dc.w See_Spikeball-See_Index
-		dc.w See_MoveSpike-See_Index
-		dc.w See_SpikeFall-See_Index
+See_Index:	offsetTable
+		ptr See_Main
+		ptr See_Slope
+		ptr See_Slope2
+		ptr See_Spikeball
+		ptr See_MoveSpike
+		ptr See_SpikeFall
 ; ===========================================================================
 
 See_Main:	; Routine 0

--- a/_incObj/5F Bomb Enemy.asm
+++ b/_incObj/5F Bomb Enemy.asm
@@ -8,10 +8,11 @@ Bomb:
 		move.w	Bom_Index(pc,d0.w),d1
 		jmp	Bom_Index(pc,d1.w)
 ; ===========================================================================
-Bom_Index:	dc.w Bom_Main-Bom_Index
-		dc.w Bom_Action-Bom_Index
-		dc.w Bom_Display-Bom_Index
-		dc.w Bom_End-Bom_Index
+Bom_Index:	offsetTable
+		ptr Bom_Main
+		ptr Bom_Action
+		ptr Bom_Display
+		ptr Bom_End
 
 bom_time = objoff_30		; time of fuse
 bom_origY = objoff_34		; original y-axis position

--- a/_incObj/60 Orbinaut.asm
+++ b/_incObj/60 Orbinaut.asm
@@ -8,11 +8,12 @@ Orbinaut:
 		move.w	Orb_Index(pc,d0.w),d1
 		jmp	Orb_Index(pc,d1.w)
 ; ===========================================================================
-Orb_Index:	dc.w Orb_Main-Orb_Index
-		dc.w Orb_ChkSonic-Orb_Index
-		dc.w Orb_Display-Orb_Index
-		dc.w Orb_MoveOrb-Orb_Index
-		dc.w Orb_ChkDel2-Orb_Index
+Orb_Index:	offsetTable
+		ptr Orb_Main
+		ptr Orb_ChkSonic
+		ptr Orb_Display
+		ptr Orb_MoveOrb
+		ptr Orb_ChkDel2
 
 orb_parent = objoff_3C		; address of parent object
 ; ===========================================================================

--- a/_incObj/61 LZ Blocks.asm
+++ b/_incObj/61 LZ Blocks.asm
@@ -8,8 +8,9 @@ LabyrinthBlock:
 		move.w	LBlk_Index(pc,d0.w),d1
 		jmp	LBlk_Index(pc,d1.w)
 ; ===========================================================================
-LBlk_Index:	dc.w LBlk_Main-LBlk_Index
-		dc.w LBlk_Action-LBlk_Index
+LBlk_Index:	offsetTable
+		ptr LBlk_Main
+		ptr LBlk_Action
 
 LBlk_Var:	dc.b $10, $10		; width, height
 		dc.b $20, $C

--- a/_incObj/62 Gargoyle.asm
+++ b/_incObj/62 Gargoyle.asm
@@ -9,10 +9,11 @@ Gargoyle:
 		jsr	Gar_Index(pc,d1.w)
 		bra.w	RememberState
 ; ===========================================================================
-Gar_Index:	dc.w Gar_Main-Gar_Index
-		dc.w Gar_MakeFire-Gar_Index
-		dc.w Gar_FireBall-Gar_Index
-		dc.w Gar_AniFire-Gar_Index
+Gar_Index:	offsetTable
+		ptr Gar_Main
+		ptr Gar_MakeFire
+		ptr Gar_FireBall
+		ptr Gar_AniFire
 
 Gar_SpitRate:	dc.b 30, 60, 90, 120, 150, 180,	210, 240
 ; ===========================================================================

--- a/_incObj/63 LZ Conveyor.asm
+++ b/_incObj/63 LZ Conveyor.asm
@@ -27,10 +27,11 @@ loc_12378:
 		bclr	#0,(a2,d0.w)
 		bra.w	DeleteObject
 ; ===========================================================================
-LCon_Index:	dc.w LCon_Main-LCon_Index
-		dc.w LCon_Platform-LCon_Index
-		dc.w LCon_OnPlatform-LCon_Index
-		dc.w LCon_Wheel-LCon_Index
+LCon_Index:	offsetTable
+		ptr LCon_Main
+		ptr LCon_Platform
+		ptr LCon_OnPlatform
+		ptr LCon_Wheel
 ; ===========================================================================
 
 LCon_Main:	; Routine 0
@@ -287,12 +288,13 @@ loc_125D4:
 ; 	dc.w entries...
 ; Entries consist of a target X position and target Y position.
 
-LCon_Data:	dc.w .group0-LCon_Data
-		dc.w .group1-LCon_Data
-		dc.w .group2-LCon_Data
-		dc.w .group3-LCon_Data
-		dc.w .group4-LCon_Data
-		dc.w .group5-LCon_Data
+LCon_Data:	offsetTable
+		ptr .group0
+		ptr .group1
+		ptr .group2
+		ptr .group3
+		ptr .group4
+		ptr .group5
 
 .group0:	
 		.baseX_0: = $1070

--- a/_incObj/64 Bubbles.asm
+++ b/_incObj/64 Bubbles.asm
@@ -8,12 +8,13 @@ Bubble:
 		move.w	Bub_Index(pc,d0.w),d1
 		jmp	Bub_Index(pc,d1.w)
 ; ===========================================================================
-Bub_Index:	dc.w Bub_Main-Bub_Index
-		dc.w Bub_Animate-Bub_Index
-		dc.w Bub_ChkWater-Bub_Index
-		dc.w Bub_Display-Bub_Index
-		dc.w Bub_Delete-Bub_Index
-		dc.w Bub_BblMaker-Bub_Index
+Bub_Index:	offsetTable
+		ptr Bub_Main
+		ptr Bub_Animate
+		ptr Bub_ChkWater
+		ptr Bub_Display
+		ptr Bub_Delete
+		ptr Bub_BblMaker
 
 bub_inhalable = objoff_2E	; flag set when bubble is collectable
 bub_origX = objoff_30		; original x-axis position

--- a/_incObj/65 Waterfalls.asm
+++ b/_incObj/65 Waterfalls.asm
@@ -8,11 +8,12 @@ Waterfall:
 		move.w	WFall_Index(pc,d0.w),d1
 		jmp	WFall_Index(pc,d1.w)
 ; ===========================================================================
-WFall_Index:	dc.w WFall_Main-WFall_Index
-		dc.w WFall_Animate-WFall_Index
-		dc.w WFall_ChkDel-WFall_Index
-		dc.w WFall_OnWater-WFall_Index
-		dc.w WFall_Priority-WFall_Index
+WFall_Index:	offsetTable
+		ptr WFall_Main
+		ptr WFall_Animate
+		ptr WFall_ChkDel
+		ptr WFall_OnWater
+		ptr WFall_Priority
 ; ===========================================================================
 
 WFall_Main:	; Routine 0

--- a/_incObj/66 Rotating Junction.asm
+++ b/_incObj/66 Rotating Junction.asm
@@ -8,10 +8,11 @@ Junction:
 		move.w	Jun_Index(pc,d0.w),d1
 		jmp	Jun_Index(pc,d1.w)
 ; ===========================================================================
-Jun_Index:	dc.w Jun_Main-Jun_Index
-		dc.w Jun_Action-Jun_Index
-		dc.w Jun_Display-Jun_Index
-		dc.w Jun_Release-Jun_Index
+Jun_Index:	offsetTable
+		ptr Jun_Main
+		ptr Jun_Action
+		ptr Jun_Display
+		ptr Jun_Release
 
 jun_frame = objoff_34		; current frame
 jun_reverse = objoff_36		; flag set when switch is pressed

--- a/_incObj/67 Running Disc.asm
+++ b/_incObj/67 Running Disc.asm
@@ -8,8 +8,9 @@ RunningDisc:
 		move.w	Disc_Index(pc,d0.w),d1
 		jmp	Disc_Index(pc,d1.w)
 ; ===========================================================================
-Disc_Index:	dc.w Disc_Main-Disc_Index
-		dc.w Disc_Action-Disc_Index
+Disc_Index:	offsetTable
+		ptr Disc_Main
+		ptr Disc_Action
 
 disc_origX = objoff_32		; original x-axis position
 disc_origY = objoff_30		; original y-axis position

--- a/_incObj/68 Conveyor Belt.asm
+++ b/_incObj/68 Conveyor Belt.asm
@@ -8,8 +8,9 @@ Conveyor:
 		move.w	Conv_Index(pc,d0.w),d1
 		jmp	Conv_Index(pc,d1.w)
 ; ===========================================================================
-Conv_Index:	dc.w Conv_Main-Conv_Index
-		dc.w Conv_Action-Conv_Index
+Conv_Index:	offsetTable
+		ptr Conv_Main
+		ptr Conv_Action
 
 conv_speed = objoff_36
 conv_width = objoff_38

--- a/_incObj/69 SBZ Spinning Platforms.asm
+++ b/_incObj/69 SBZ Spinning Platforms.asm
@@ -8,9 +8,10 @@ SpinPlatform:
 		move.w	Spin_Index(pc,d0.w),d1
 		jmp	Spin_Index(pc,d1.w)
 ; ===========================================================================
-Spin_Index:	dc.w Spin_Main-Spin_Index
-		dc.w Spin_Trapdoor-Spin_Index
-		dc.w Spin_Spinner-Spin_Index
+Spin_Index:	offsetTable
+		ptr Spin_Main
+		ptr Spin_Trapdoor
+		ptr Spin_Spinner
 
 spin_timer = objoff_30		; time counter until change
 spin_timelen = objoff_32	; time between changes (general)

--- a/_incObj/6A Saws and Pizza Cutters.asm
+++ b/_incObj/6A Saws and Pizza Cutters.asm
@@ -8,8 +8,9 @@ Saws:
 		move.w	Saw_Index(pc,d0.w),d1
 		jmp	Saw_Index(pc,d1.w)
 ; ===========================================================================
-Saw_Index:	dc.w Saw_Main-Saw_Index
-		dc.w Saw_Action-Saw_Index
+Saw_Index:	offsetTable
+		ptr Saw_Main
+		ptr Saw_Action
 
 saw_origX = objoff_3A		; original x-axis position
 saw_origY = objoff_38		; original y-axis position

--- a/_incObj/6B SBZ Stomper and Door.asm
+++ b/_incObj/6B SBZ Stomper and Door.asm
@@ -8,8 +8,9 @@ ScrapStomp:
 		move.w	Sto_Index(pc,d0.w),d1
 		jmp	Sto_Index(pc,d1.w)
 ; ===========================================================================
-Sto_Index:	dc.w Sto_Main-Sto_Index
-		dc.w Sto_Action-Sto_Index
+Sto_Index:	offsetTable
+		ptr Sto_Main
+		ptr Sto_Action
 
 sto_origX = objoff_34		; original x-axis position
 sto_origY = objoff_30		; original y-axis position

--- a/_incObj/6C SBZ Vanishing Platforms.asm
+++ b/_incObj/6C SBZ Vanishing Platforms.asm
@@ -8,10 +8,11 @@ VanishPlatform:
 		move.w	VanP_Index(pc,d0.w),d1
 		jmp	VanP_Index(pc,d1.w)
 ; ===========================================================================
-VanP_Index:	dc.w VanP_Main-VanP_Index
-		dc.w VanP_Detect-VanP_Index
-		dc.w VanP_StoodOn-VanP_Index
-		dc.w VanP_Sync-VanP_Index
+VanP_Index:	offsetTable
+		ptr VanP_Main
+		ptr VanP_Detect
+		ptr VanP_StoodOn
+		ptr VanP_Sync
 
 vanp_timer = objoff_30		; counter for time until event
 vanp_timelen = objoff_32	; time between events (general)

--- a/_incObj/6D Flamethrower.asm
+++ b/_incObj/6D Flamethrower.asm
@@ -8,8 +8,9 @@ Flamethrower:
 		move.w	Flame_Index(pc,d0.w),d1
 		jmp	Flame_Index(pc,d1.w)
 ; ===========================================================================
-Flame_Index:	dc.w Flame_Main-Flame_Index
-		dc.w Flame_Action-Flame_Index
+Flame_Index:	offsetTable
+		ptr Flame_Main
+		ptr Flame_Action
 ; ===========================================================================
 
 Flame_Main:	; Routine 0

--- a/_incObj/6E Electrocuter.asm
+++ b/_incObj/6E Electrocuter.asm
@@ -8,8 +8,9 @@ Electro:
 		move.w	Elec_Index(pc,d0.w),d1
 		jmp	Elec_Index(pc,d1.w)
 ; ===========================================================================
-Elec_Index:	dc.w Elec_Main-Elec_Index
-		dc.w Elec_Shock-Elec_Index
+Elec_Index:	offsetTable
+		ptr Elec_Main
+		ptr Elec_Shock
 
 elec_freq = objoff_34		; frequency
 ; ===========================================================================

--- a/_incObj/6F SBZ Spin Platform Conveyor.asm
+++ b/_incObj/6F SBZ Spin Platform Conveyor.asm
@@ -29,8 +29,9 @@ SpinC_Act1or2:
 SpinC_Delete:
 		jmp	(DeleteObject).l
 ; ===========================================================================
-SpinC_Index:	dc.w SpinC_Main-SpinC_Index
-		dc.w SpinC_Solid-SpinC_Index
+SpinC_Index:	offsetTable
+		ptr SpinC_Main
+		ptr SpinC_Solid
 ; ===========================================================================
 
 SpinC_Main:	; Routine 0
@@ -209,12 +210,13 @@ loc_16484:
 ; 	dc.w entries...
 ; Entries consist of a target X position and target Y position.
 
-SpinC_Data:	dc.w .group0-SpinC_Data
-		dc.w .group1-SpinC_Data
-		dc.w .group2-SpinC_Data
-		dc.w .group3-SpinC_Data
-		dc.w .group4-SpinC_Data
-		dc.w .group5-SpinC_Data
+SpinC_Data:	offsetTable
+		ptr .group0
+		ptr .group1
+		ptr .group2
+		ptr .group3
+		ptr .group4
+		ptr .group5
 
 .group0:
 		.baseX_0: = $E80

--- a/_incObj/70 Girder Block.asm
+++ b/_incObj/70 Girder Block.asm
@@ -8,8 +8,9 @@ Girder:
 		move.w	Gird_Index(pc,d0.w),d1
 		jmp	Gird_Index(pc,d1.w)
 ; ===========================================================================
-Gird_Index:	dc.w Gird_Main-Gird_Index
-		dc.w Gird_Action-Gird_Index
+Gird_Index:	offsetTable
+		ptr Gird_Main
+		ptr Gird_Action
 
 gird_origX = objoff_32		; original x-axis position
 gird_origY = objoff_30		; original y-axis position

--- a/_incObj/71 Invisible Barriers.asm
+++ b/_incObj/71 Invisible Barriers.asm
@@ -8,8 +8,9 @@ Invisibarrier:
 		move.w	Invis_Index(pc,d0.w),d1
 		jmp	Invis_Index(pc,d1.w)
 ; ===========================================================================
-Invis_Index:	dc.w Invis_Main-Invis_Index
-		dc.w Invis_Solid-Invis_Index
+Invis_Index:	offsetTable
+		ptr Invis_Main
+		ptr Invis_Solid
 ; ===========================================================================
 
 Invis_Main:	; Routine 0

--- a/_incObj/72 Teleporter.asm
+++ b/_incObj/72 Teleporter.asm
@@ -13,10 +13,11 @@ Teleport:
 .delete:
 		jmp	(DeleteObject).l
 ; ===========================================================================
-Tele_Index:	dc.w Tele_Main-Tele_Index
-		dc.w Tele_Action-Tele_Index
-		dc.w Tele_Bump-Tele_Index
-		dc.w Tele_Bend-Tele_Index
+Tele_Index:	offsetTable
+		ptr Tele_Main
+		ptr Tele_Action
+		ptr Tele_Bump
+		ptr Tele_Bend
 ; ===========================================================================
 
 Tele_Main:	; Routine 0
@@ -217,14 +218,15 @@ loc_168A6:
 ; End of function sub_1681C
 
 ; ===========================================================================
-Tele_Data:	dc.w .type00-Tele_Data
-		dc.w .type01-Tele_Data
-		dc.w .type02-Tele_Data
-		dc.w .type03-Tele_Data
-		dc.w .type04-Tele_Data
-		dc.w .type05-Tele_Data
-		dc.w .type06-Tele_Data
-		dc.w .type07-Tele_Data
+Tele_Data:	offsetTable
+		ptr .type00
+		ptr .type01
+		ptr .type02
+		ptr .type03
+		ptr .type04
+		ptr .type05
+		ptr .type06
+		ptr .type07
 
 .type00:	dc.w 4,	$794, $98C
 

--- a/_incObj/73 Boss - Marble.asm
+++ b/_incObj/73 Boss - Marble.asm
@@ -8,12 +8,12 @@ BossMarble:
 		move.w	BossMarble_Index(pc,d0.w),d1
 		jmp	BossMarble_Index(pc,d1.w)
 ; ===========================================================================
-BossMarble_Index:
-		dc.w BossMarble_Main-BossMarble_Index
-		dc.w BossMarble_ShipMain-BossMarble_Index
-		dc.w BossMarble_FaceMain-BossMarble_Index
-		dc.w BossMarble_FlameMain-BossMarble_Index
-		dc.w BossMarble_TubeMain-BossMarble_Index
+BossMarble_Index: offsetTable
+		ptr BossMarble_Main
+		ptr BossMarble_ShipMain
+		ptr BossMarble_FaceMain
+		ptr BossMarble_FlameMain
+		ptr BossMarble_TubeMain
 
 BossMarble_ObjData:
 		dc.b 2,	0, 4		; routine number, animation, priority
@@ -66,12 +66,12 @@ BossMarble_ShipMain:	; Routine 2
 		or.b	d0,obRender(a0)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-BossMarble_ShipIndex:
-		dc.w BMZ_ShipStart-BossMarble_ShipIndex
-		dc.w BMZ_ShipMove-BossMarble_ShipIndex
-		dc.w BMZ_Explode-BossMarble_ShipIndex
-		dc.w BMZ_Recover-BossMarble_ShipIndex
-		dc.w BMZ_Escape-BossMarble_ShipIndex
+BossMarble_ShipIndex: offsetTable
+		ptr BMZ_ShipStart
+		ptr BMZ_ShipMove
+		ptr BMZ_Explode
+		ptr BMZ_Recover
+		ptr BMZ_Escape
 ; ===========================================================================
 
 ; loc_18302:
@@ -143,10 +143,11 @@ BMZ_ShipMove:
 		andi.b	#6,obSubtype(a0)
 		bra.w	loc_1833E
 ; ===========================================================================
-off_183C2:	dc.w BMZ_ChgDir-off_183C2
-		dc.w BMZ_DropFire-off_183C2
-		dc.w BMZ_ChgDir-off_183C2
-		dc.w BMZ_DropFire-off_183C2
+off_183C2:	offsetTable
+		ptr BMZ_ChgDir
+		ptr BMZ_DropFire
+		ptr BMZ_ChgDir
+		ptr BMZ_DropFire
 ; ===========================================================================
 
 ; loc_183CA:

--- a/_incObj/74 MZ Boss Fire.asm
+++ b/_incObj/74 MZ Boss Fire.asm
@@ -14,10 +14,11 @@ BossFire:
 		jmp	(DisplaySprite).l
 	endif
 ; ===========================================================================
-BossFire_Index:	dc.w BossFire_Main-BossFire_Index
-		dc.w BossFire_Action-BossFire_Index
-		dc.w BossFire_TempFire-BossFire_Index
-		dc.w BossFire_TempFireDel-BossFire_Index
+BossFire_Index:	offsetTable
+		ptr BossFire_Main
+		ptr BossFire_Action
+		ptr BossFire_TempFire
+		ptr BossFire_TempFireDel
 ; ===========================================================================
 
 BossFire_Main:	; Routine 0
@@ -63,10 +64,11 @@ BossFire_Action:	; Routine 2
 BossFire_Delete:
 		jmp	(DeleteObject).l
 ; ===========================================================================
-BossFire_Index2:dc.w BossFire_Drop-BossFire_Index2
-		dc.w BossFire_MakeFlame-BossFire_Index2
-		dc.w BossFire_Duplicate-BossFire_Index2
-		dc.w BossFire_FallEdge-BossFire_Index2
+BossFire_Index2: offsetTable
+		ptr BossFire_Drop
+		ptr BossFire_MakeFlame
+		ptr BossFire_Duplicate
+		ptr BossFire_FallEdge
 ; ===========================================================================
 
 BossFire_Drop:

--- a/_incObj/75 Boss - Spring Yard.asm
+++ b/_incObj/75 Boss - Spring Yard.asm
@@ -8,12 +8,12 @@ BossSpringYard:
 		move.w	BossSpringYard_Index(pc,d0.w),d1
 		jmp	BossSpringYard_Index(pc,d1.w)
 ; ===========================================================================
-BossSpringYard_Index:
-		dc.w BossSpringYard_Main-BossSpringYard_Index
-		dc.w BossSpringYard_ShipMain-BossSpringYard_Index
-		dc.w BossSpringYard_FaceMain-BossSpringYard_Index
-		dc.w BossSpringYard_FlameMain-BossSpringYard_Index
-		dc.w BossSpringYard_SpikeMain-BossSpringYard_Index
+BossSpringYard_Index: offsetTable
+		ptr BossSpringYard_Main
+		ptr BossSpringYard_ShipMain
+		ptr BossSpringYard_FaceMain
+		ptr BossSpringYard_FlameMain
+		ptr BossSpringYard_SpikeMain
 
 BossSpringYard_ObjData:
 		dc.b 2,	0, 5		; routine number, animation, priority
@@ -68,13 +68,13 @@ BossSpringYard_ShipMain:	; Routine 2
 		or.b	d0,obRender(a0)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-BossSpringYard_ShipIndex:
-		dc.w BSYZ_ShipStart-BossSpringYard_ShipIndex
-		dc.w BSYZ_ShipMove-BossSpringYard_ShipIndex
-		dc.w BSYZ_Attack-BossSpringYard_ShipIndex
-		dc.w BSYZ_Explode-BossSpringYard_ShipIndex
-		dc.w BSYZ_Recover-BossSpringYard_ShipIndex
-		dc.w BSYZ_Escape-BossSpringYard_ShipIndex
+BossSpringYard_ShipIndex: offsetTable
+		ptr BSYZ_ShipStart
+		ptr BSYZ_ShipMove
+		ptr BSYZ_Attack
+		ptr BSYZ_Explode
+		ptr BSYZ_Recover
+		ptr BSYZ_Escape
 ; ===========================================================================
 
 ; loc_191CC:
@@ -197,10 +197,11 @@ BSYZ_Attack:
 		move.w	off_192FA(pc,d0.w),d0
 		jmp	off_192FA(pc,d0.w)
 ; ===========================================================================
-off_192FA:	dc.w BSYZ_Descend-off_192FA
-		dc.w BSYZ_Lift-off_192FA
-		dc.w BSYZ_LiftStop-off_192FA
-		dc.w BSYZ_BreakBlock-off_192FA
+off_192FA:	offsetTable
+		ptr BSYZ_Descend
+		ptr BSYZ_Lift
+		ptr BSYZ_LiftStop
+		ptr BSYZ_BreakBlock
 ; ===========================================================================
 
 ; loc_19302:
@@ -484,12 +485,13 @@ BossSpringYard_FaceMain:	; Routine 4
 BossSpringYard_FaceDelete:
 		jmp	(DeleteObject).l
 ; ===========================================================================
-off_19546:	dc.w BSYZ_Face_ChkHit-off_19546
-		dc.w BSYZ_Face_ChkHit-off_19546
-		dc.w BSYZ_Face_Attack-off_19546
-		dc.w BSYZ_Face_Defeat-off_19546
-		dc.w BSYZ_Face_Defeat-off_19546
-		dc.w BSYZ_Face_Escape-off_19546
+off_19546:	offsetTable
+		ptr BSYZ_Face_ChkHit
+		ptr BSYZ_Face_ChkHit
+		ptr BSYZ_Face_Attack
+		ptr BSYZ_Face_Defeat
+		ptr BSYZ_Face_Defeat
+		ptr BSYZ_Face_Escape
 ; ===========================================================================
 
 ; loc_19552:
@@ -511,10 +513,11 @@ BSYZ_Face_Attack:
 		move.w	off_19568(pc,d0.w),d0
 		jmp	off_19568(pc,d0.w)
 ; ===========================================================================
-off_19568:	dc.w BSYZ_Face_Attack_Other-off_19568
-		dc.w BSYZ_Face_Attack_Lift-off_19568
-		dc.w BSYZ_Face_Attack_Other-off_19568
-		dc.w BSYZ_Face_Attack_Other-off_19568
+off_19568:	offsetTable
+		ptr BSYZ_Face_Attack_Other
+		ptr BSYZ_Face_Attack_Lift
+		ptr BSYZ_Face_Attack_Other
+		ptr BSYZ_Face_Attack_Other
 ; ===========================================================================
 
 ; loc_19570:

--- a/_incObj/76 SYZ Boss Blocks.asm
+++ b/_incObj/76 SYZ Boss Blocks.asm
@@ -8,10 +8,10 @@ BossBlock:
 		move.w	BossBlock_Index(pc,d0.w),d1
 		jmp	BossBlock_Index(pc,d1.w)
 ; ===========================================================================
-BossBlock_Index:
-		dc.w BossBlock_Main-BossBlock_Index
-		dc.w BossBlock_Action-BossBlock_Index
-		dc.w BossBlock_Frag-BossBlock_Index
+BossBlock_Index: offsetTable
+		ptr BossBlock_Main
+		ptr BossBlock_Action
+		ptr BossBlock_Frag
 ; ===========================================================================
 
 BossBlock_Main:	; Routine 0

--- a/_incObj/77 Boss - Labyrinth.asm
+++ b/_incObj/77 Boss - Labyrinth.asm
@@ -8,11 +8,11 @@ BossLabyrinth:
 		move.w	BossLabyrinth_Index(pc,d0.w),d1
 		jmp	BossLabyrinth_Index(pc,d1.w)
 ; ===========================================================================
-BossLabyrinth_Index:
-		dc.w BossLabyrinth_Main-BossLabyrinth_Index
-		dc.w BossLabyrinth_ShipMain-BossLabyrinth_Index
-		dc.w BossLabyrinth_FaceMain-BossLabyrinth_Index
-		dc.w BossLabyrinth_FlameMain-BossLabyrinth_Index
+BossLabyrinth_Index: offsetTable
+		ptr BossLabyrinth_Main
+		ptr BossLabyrinth_ShipMain
+		ptr BossLabyrinth_FaceMain
+		ptr BossLabyrinth_FlameMain
 
 BossLabyrinth_ObjData:
 		dc.b 2,	0		; routine number, animation
@@ -68,15 +68,15 @@ BossLabyrinth_ShipMain:	; Routine 2
 		or.b	d0,obRender(a0)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-BossLabyrinth_ShipIndex:
-		dc.w BLZ_ShipStart-BossLabyrinth_ShipIndex
-		dc.w BLZ_ShipMove1-BossLabyrinth_ShipIndex
-		dc.w BLZ_ShipMove2-BossLabyrinth_ShipIndex
-		dc.w BLZ_ShipMove3-BossLabyrinth_ShipIndex
-		dc.w BLZ_ShipAtTop-BossLabyrinth_ShipIndex
-		dc.w BLZ_ShipWait-BossLabyrinth_ShipIndex
-		dc.w BLZ_Escape1-BossLabyrinth_ShipIndex
-		dc.w BLZ_Escape2-BossLabyrinth_ShipIndex
+BossLabyrinth_ShipIndex: offsetTable
+		ptr BLZ_ShipStart
+		ptr BLZ_ShipMove1
+		ptr BLZ_ShipMove2
+		ptr BLZ_ShipMove3
+		ptr BLZ_ShipAtTop
+		ptr BLZ_ShipWait
+		ptr BLZ_Escape1
+		ptr BLZ_Escape2
 ; ===========================================================================
 
 ; loc_17F1E:

--- a/_incObj/78 Caterkiller.asm
+++ b/_incObj/78 Caterkiller.asm
@@ -8,13 +8,14 @@ Caterkiller:
 		move.w	Cat_Index(pc,d0.w),d1
 		jmp	Cat_Index(pc,d1.w)
 ; ===========================================================================
-Cat_Index:	dc.w Cat_Main-Cat_Index
-		dc.w Cat_Head-Cat_Index
-		dc.w Cat_BodySeg1-Cat_Index
-		dc.w Cat_BodySeg2-Cat_Index
-		dc.w Cat_BodySeg1-Cat_Index
-		dc.w Cat_Delete-Cat_Index
-		dc.w Cat_Fragment-Cat_Index
+Cat_Index:	offsetTable
+		ptr Cat_Main
+		ptr Cat_Head
+		ptr Cat_BodySeg1
+		ptr Cat_BodySeg2
+		ptr Cat_BodySeg1
+		ptr Cat_Delete
+		ptr Cat_Fragment
 
 cat_parent = objoff_3C		; address of parent object
 ; ===========================================================================
@@ -133,8 +134,9 @@ Cat_ChkGone:
 Cat_Delete:	; Routine $A
 		jmp	(DeleteObject).l
 ; ===========================================================================
-Cat_Index2:	dc.w Cat_Undulate-Cat_Index2
-		dc.w Cat_Floor-Cat_Index2
+Cat_Index2:	offsetTable
+		ptr Cat_Undulate
+		ptr Cat_Floor
 ; ===========================================================================
 
 ; .wait:

--- a/_incObj/79 Lamppost.asm
+++ b/_incObj/79 Lamppost.asm
@@ -9,10 +9,11 @@ Lamppost:
 		jsr	Lamp_Index(pc,d1.w)
 		jmp	(RememberState).l
 ; ===========================================================================
-Lamp_Index:	dc.w Lamp_Main-Lamp_Index
-		dc.w Lamp_Blue-Lamp_Index
-		dc.w Lamp_Finish-Lamp_Index
-		dc.w Lamp_Twirl-Lamp_Index
+Lamp_Index:	offsetTable
+		ptr Lamp_Main
+		ptr Lamp_Blue
+		ptr Lamp_Finish
+		ptr Lamp_Twirl
 
 lamp_origX = objoff_30		; original x-axis position
 lamp_origY = objoff_32		; original y-axis position

--- a/_incObj/7A Boss - Star Light.asm
+++ b/_incObj/7A Boss - Star Light.asm
@@ -12,12 +12,12 @@ BossStarLight:
 		move.w	BossStarLight_Index(pc,d0.w),d1
 		jmp	BossStarLight_Index(pc,d1.w)
 ; ===========================================================================
-BossStarLight_Index:
-		dc.w BossStarLight_Main-BossStarLight_Index
-		dc.w BossStarLight_ShipMain-BossStarLight_Index
-		dc.w BossStarLight_FaceMain-BossStarLight_Index
-		dc.w BossStarLight_FlameMain-BossStarLight_Index
-		dc.w BossStarLight_TubeMain-BossStarLight_Index
+BossStarLight_Index: offsetTable
+		ptr BossStarLight_Main
+		ptr BossStarLight_ShipMain
+		ptr BossStarLight_FaceMain
+		ptr BossStarLight_FlameMain
+		ptr BossStarLight_TubeMain
 
 BossStarLight_ObjData:	dc.b 2,	0, 4		; routine number, animation, priority
 		dc.b 4,	1, 4
@@ -96,13 +96,13 @@ BossStarLight_ShipMain:	; Routine 2
 		or.b	d0,obRender(a0)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-BossStarLight_ShipIndex:
-		dc.w BSLZ_ShipStart-BossStarLight_ShipIndex
-		dc.w BSLZ_ShipMove-BossStarLight_ShipIndex
-		dc.w BSLZ_MakeBall-BossStarLight_ShipIndex
-		dc.w BSLZ_Explode-BossStarLight_ShipIndex
-		dc.w BSLZ_Recover-BossStarLight_ShipIndex
-		dc.w BSLZ_Escape-BossStarLight_ShipIndex
+BossStarLight_ShipIndex: offsetTable
+		ptr BSLZ_ShipStart
+		ptr BSLZ_ShipMove
+		ptr BSLZ_MakeBall
+		ptr BSLZ_Explode
+		ptr BSLZ_Recover
+		ptr BSLZ_Escape
 ; ===========================================================================
 
 ; loc_189B8:

--- a/_incObj/7B SLZ Boss Spikeball.asm
+++ b/_incObj/7B SLZ Boss Spikeball.asm
@@ -18,13 +18,13 @@ BossSpikeball:
 		bhi.w	BossStarLight_Delete
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-BossSpikeball_Index:
-		dc.w BossSpikeball_Main-BossSpikeball_Index
-		dc.w BossSpikeball_Fall-BossSpikeball_Index
-		dc.w BossSpikeball_Bounce-BossSpikeball_Index
-		dc.w BossSpikeball_HitBoss-BossSpikeball_Index
-		dc.w BossSpikeball_Explode-BossSpikeball_Index
-		dc.w BossSpikeball_MoveFrag-BossSpikeball_Index
+BossSpikeball_Index: offsetTable
+		ptr BossSpikeball_Main
+		ptr BossSpikeball_Fall
+		ptr BossSpikeball_Bounce
+		ptr BossSpikeball_HitBoss
+		ptr BossSpikeball_Explode
+		ptr BossSpikeball_MoveFrag
 ; ===========================================================================
 
 BossSpikeball_Main:	; Routine 0

--- a/_incObj/7C Ring Flash.asm
+++ b/_incObj/7C Ring Flash.asm
@@ -8,9 +8,10 @@ RingFlash:
 		move.w	Flash_Index(pc,d0.w),d1
 		jmp	Flash_Index(pc,d1.w)
 ; ===========================================================================
-Flash_Index:	dc.w Flash_Main-Flash_Index
-		dc.w Flash_ChkDel-Flash_Index
-		dc.w Flash_Delete-Flash_Index
+Flash_Index:	offsetTable
+		ptr Flash_Main
+		ptr Flash_ChkDel
+		ptr Flash_Delete
 ; ===========================================================================
 
 Flash_Main:	; Routine 0

--- a/_incObj/7D Hidden Bonuses.asm
+++ b/_incObj/7D Hidden Bonuses.asm
@@ -8,8 +8,9 @@ HiddenBonus:
 		move.w	Bonus_Index(pc,d0.w),d1
 		jmp	Bonus_Index(pc,d1.w)
 ; ===========================================================================
-Bonus_Index:	dc.w Bonus_Main-Bonus_Index
-		dc.w Bonus_Display-Bonus_Index
+Bonus_Index:	offsetTable
+		ptr Bonus_Main
+		ptr Bonus_Display
 
 bonus_timelen = objoff_30		; length of time to display bonus sprites
 ; ===========================================================================

--- a/_incObj/7E Special Stage Results.asm
+++ b/_incObj/7E Special Stage Results.asm
@@ -8,17 +8,18 @@ SSResult:
 		move.w	SSR_Index(pc,d0.w),d1
 		jmp	SSR_Index(pc,d1.w)
 ; ===========================================================================
-SSR_Index:	dc.w SSR_ChkPLC-SSR_Index
-		dc.w SSR_Move-SSR_Index
-		dc.w SSR_Wait-SSR_Index
-		dc.w SSR_RingBonus-SSR_Index
-		dc.w SSR_Wait-SSR_Index
-		dc.w SSR_Exit-SSR_Index
-		dc.w SSR_Wait-SSR_Index
-		dc.w SSR_Continue-SSR_Index
-		dc.w SSR_Wait-SSR_Index
-		dc.w SSR_Exit-SSR_Index
-		dc.w SSR_ContAni-SSR_Index
+SSR_Index:	offsetTable
+		ptr SSR_ChkPLC
+		ptr SSR_Move
+		ptr SSR_Wait
+		ptr SSR_RingBonus
+		ptr SSR_Wait
+		ptr SSR_Exit
+		ptr SSR_Wait
+		ptr SSR_Continue
+		ptr SSR_Wait
+		ptr SSR_Exit
+		ptr SSR_ContAni
 
 ssr_mainX = objoff_30		; position for card to display on
 ; ===========================================================================

--- a/_incObj/7F SS Result Chaos Emeralds.asm
+++ b/_incObj/7F SS Result Chaos Emeralds.asm
@@ -8,8 +8,9 @@ SSRChaos:
 		move.w	SSRC_Index(pc,d0.w),d1
 		jmp	SSRC_Index(pc,d1.w)
 ; ===========================================================================
-SSRC_Index:	dc.w SSRC_Main-SSRC_Index
-		dc.w SSRC_Flash-SSRC_Index
+SSRC_Index:	offsetTable
+		ptr SSRC_Main
+		ptr SSRC_Flash
 
 ; ---------------------------------------------------------------------------
 ; X-axis positions for chaos emeralds

--- a/_incObj/80 & 81 Continue Screen Elements and Sonic.asm
+++ b/_incObj/80 & 81 Continue Screen Elements and Sonic.asm
@@ -8,10 +8,11 @@ ContScrItem:
 		move.w	CSI_Index(pc,d0.w),d1
 		jmp	CSI_Index(pc,d1.w)
 ; ===========================================================================
-CSI_Index:	dc.w CSI_Main-CSI_Index
-		dc.w CSI_Display-CSI_Index
-		dc.w CSI_MakeMiniSonic-CSI_Index
-		dc.w CSI_ChkDel-CSI_Index
+CSI_Index:	offsetTable
+		ptr CSI_Main
+		ptr CSI_Display
+		ptr CSI_MakeMiniSonic
+		ptr CSI_ChkDel
 ; ===========================================================================
 
 CSI_Main:	; Routine 0
@@ -111,10 +112,11 @@ ContSonic:
 		jsr	CSon_Index(pc,d1.w)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-CSon_Index:	dc.w CSon_Main-CSon_Index
-		dc.w CSon_ChkLand-CSon_Index
-		dc.w CSon_Animate-CSon_Index
-		dc.w CSon_Run-CSon_Index
+CSon_Index:	offsetTable
+		ptr CSon_Main
+		ptr CSon_ChkLand
+		ptr CSon_Animate
+		ptr CSon_Run
 ; ===========================================================================
 
 CSon_Main:	; Routine 0

--- a/_incObj/82 Eggman - Scrap Brain 2.asm
+++ b/_incObj/82 Eggman - Scrap Brain 2.asm
@@ -15,9 +15,10 @@ ScrapEggman:
 		move.w	SEgg_Index(pc,d0.w),d1
 		jmp	SEgg_Index(pc,d1.w)
 ; ===========================================================================
-SEgg_Index:	dc.w SEgg_Main-SEgg_Index
-		dc.w SEgg_Eggman-SEgg_Index
-		dc.w SEgg_Switch-SEgg_Index
+SEgg_Index:	offsetTable
+		ptr SEgg_Main
+		ptr SEgg_Eggman
+		ptr SEgg_Switch
 
 SEgg_ObjData:	dc.b 2,	0, 3		; routine number, animation, priority
 		dc.b 4,	0, 3
@@ -65,10 +66,11 @@ SEgg_Eggman:	; Routine 2
 		jsr	(AnimateSprite).l
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-SEgg_EggIndex:	dc.w SEgg_ChkSonic-SEgg_EggIndex
-		dc.w SEgg_PreLeap-SEgg_EggIndex
-		dc.w SEgg_Leap-SEgg_EggIndex
-		dc.w SEgg_Move-SEgg_EggIndex
+SEgg_EggIndex:	offsetTable
+		ptr SEgg_ChkSonic
+		ptr SEgg_PreLeap
+		ptr SEgg_Leap
+		ptr SEgg_Move
 ; ===========================================================================
 
 SEgg_ChkSonic:
@@ -155,8 +157,9 @@ SEgg_Switch:	; Routine 4
 		move.w	SEgg_SwIndex(pc,d0.w),d0
 		jmp	SEgg_SwIndex(pc,d0.w)
 ; ===========================================================================
-SEgg_SwIndex:	dc.w SEgg_SwChk-SEgg_SwIndex
-		dc.w SEgg_SwDisplay-SEgg_SwIndex
+SEgg_SwIndex:	offsetTable
+		ptr SEgg_SwChk
+		ptr SEgg_SwDisplay
 ; ===========================================================================
 
 ; loc_199E6:

--- a/_incObj/83 SBZ Eggman's Crumbling Floor.asm
+++ b/_incObj/83 SBZ Eggman's Crumbling Floor.asm
@@ -8,12 +8,13 @@ FalseFloor:
 		move.w	FFloor_Index(pc,d0.w),d1
 		jmp	FFloor_Index(pc,d1.w)
 ; ===========================================================================
-FFloor_Index:	dc.w FFloor_Main-FFloor_Index
-		dc.w FFloor_ChkBreak-FFloor_Index
-		dc.w FFloor_Break-FFloor_Index
-		dc.w FFloor_AllGone-FFloor_Index
-		dc.w FFloor_Block-FFloor_Index
-		dc.w FFloor_Frag-FFloor_Index
+FFloor_Index:	offsetTable
+		ptr FFloor_Main
+		ptr FFloor_ChkBreak
+		ptr FFloor_Break
+		ptr FFloor_AllGone
+		ptr FFloor_Block
+		ptr FFloor_Frag
 ; ===========================================================================
 
 FFloor_Main:	; Routine 0

--- a/_incObj/84 FZ Eggman's Cylinders.asm
+++ b/_incObj/84 FZ Eggman's Cylinders.asm
@@ -12,10 +12,10 @@ EggmanCylinder:
 		move.w	EggmanCylinder_Index(pc,d0.w),d0
 		jmp	EggmanCylinder_Index(pc,d0.w)
 ; ===========================================================================
-EggmanCylinder_Index:
-		dc.w EggmanCylinder_Main-EggmanCylinder_Index
-		dc.w EggmanCylinder_Action-EggmanCylinder_Index
-		dc.w EggmanCylinder_Move-EggmanCylinder_Index
+EggmanCylinder_Index: offsetTable
+		ptr EggmanCylinder_Main
+		ptr EggmanCylinder_Action
+		ptr EggmanCylinder_Move
 
 EggmanCylinder_PosData:
 		dc.w boss_fz_x+$80,  boss_fz_y+$110
@@ -125,10 +125,11 @@ EggmanCylinder_Move: ; Routine 4
 		jsr	off_1A590(pc,d0.w)
 		bra.w	loc_1A4EA
 ; ===========================================================================
-off_1A590:	dc.w EggmanCylinder_Bottom-off_1A590	; bottom left
-		dc.w EggmanCylinder_Bottom-off_1A590	; bottom right
-		dc.w EggmanCylinder_Top-off_1A590	; top left
-		dc.w EggmanCylinder_Top-off_1A590	; top right
+off_1A590:	offsetTable
+		ptr EggmanCylinder_Bottom	; bottom left
+		ptr EggmanCylinder_Bottom	; bottom right
+		ptr EggmanCylinder_Top		; top left
+		ptr EggmanCylinder_Top		; top right
 ; ===========================================================================
 
 ; loc_1A598:

--- a/_incObj/85 Boss - Final.asm
+++ b/_incObj/85 Boss - Final.asm
@@ -12,14 +12,14 @@ BossFinal:
 		move.w	BossFinal_Index(pc,d0.w),d0
 		jmp	BossFinal_Index(pc,d0.w)
 ; ===========================================================================
-BossFinal_Index:
-		dc.w BossFinal_Main-BossFinal_Index
-		dc.w BossFinal_Eggman-BossFinal_Index
-		dc.w BossFinal_Panel-BossFinal_Index
-		dc.w BossFinal_Legs-BossFinal_Index
-		dc.w BossFinal_Cockpit-BossFinal_Index
-		dc.w BossFinal_EmptyShip-BossFinal_Index
-		dc.w BossFinal_Flame-BossFinal_Index
+BossFinal_Index: offsetTable
+		ptr BossFinal_Main
+		ptr BossFinal_Eggman
+		ptr BossFinal_Panel
+		ptr BossFinal_Legs
+		ptr BossFinal_Cockpit
+		ptr BossFinal_EmptyShip
+		ptr BossFinal_Flame
 
 BossFinal_ObjData:
 		dc.w $100, $100, ArtTile_FZ_Eggman_No_Vehicle	; X pos, Y pos, VRAM setting
@@ -109,14 +109,15 @@ BossFinal_Eggman:	; Routine 2
 		jsr	off_19E80(pc,d0.w)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-off_19E80:	dc.w BossFinal_Eggman_Wait-off_19E80
-		dc.w BossFinal_Eggman_Crush-off_19E80
-		dc.w BossFinal_Eggman_Plasma-off_19E80
-		dc.w BossFinal_Eggman_Fall-off_19E80
-		dc.w BossFinal_Eggman_Run-off_19E80
-		dc.w BossFinal_Eggman_Jump-off_19E80
-		dc.w BossFinal_Eggman_Ship-off_19E80
-		dc.w BossFinal_Eggman_Escape-off_19E80
+off_19E80:	offsetTable
+		ptr BossFinal_Eggman_Wait
+		ptr BossFinal_Eggman_Crush
+		ptr BossFinal_Eggman_Plasma
+		ptr BossFinal_Eggman_Fall
+		ptr BossFinal_Eggman_Run
+		ptr BossFinal_Eggman_Jump
+		ptr BossFinal_Eggman_Ship
+		ptr BossFinal_Eggman_Escape
 ; ===========================================================================
 
 ; loc_19E90:

--- a/_incObj/86 FZ Plasma Ball Launcher.asm
+++ b/_incObj/86 FZ Plasma Ball Launcher.asm
@@ -8,12 +8,12 @@ BossPlasma:
 		move.w	BossPlasma_Index(pc,d0.w),d0
 		jmp	BossPlasma_Index(pc,d0.w)
 ; ===========================================================================
-BossPlasma_Index:
-		dc.w BossPlasma_Main-BossPlasma_Index
-		dc.w BossPlasma_Generator-BossPlasma_Index
-		dc.w BossPlasma_MakeBalls-BossPlasma_Index
-		dc.w BossPlasma_Finish-BossPlasma_Index
-		dc.w BossPlasma_Balls-BossPlasma_Index
+BossPlasma_Index: offsetTable
+		ptr BossPlasma_Main
+		ptr BossPlasma_Generator
+		ptr BossPlasma_MakeBalls
+		ptr BossPlasma_Finish
+		ptr BossPlasma_Balls
 ; ===========================================================================
 
 BossPlasma_Main:	; Routine 0
@@ -143,10 +143,10 @@ BossPlasma_Balls: ; Routine 8
 		jsr	(AnimateSprite).l
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-BossPlasma_Index2:
-		dc.w BossPlasma_Spread-BossPlasma_Index2
-		dc.w BossPlasma_Drop-BossPlasma_Index2
-		dc.w BossPlasma_Move-BossPlasma_Index2
+BossPlasma_Index2: offsetTable
+		ptr BossPlasma_Spread
+		ptr BossPlasma_Drop
+		ptr BossPlasma_Move
 ; ===========================================================================
 
 ; loc_1A9A6:

--- a/_incObj/87, 88 & 89 Ending Sequence Sonic, Emeralds, Logo.asm
+++ b/_incObj/87, 88 & 89 Ending Sequence Sonic, Emeralds, Logo.asm
@@ -9,16 +9,17 @@ EndSonic:
 		jsr	ESon_Index(pc,d1.w)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-ESon_Index:	dc.w ESon_Main-ESon_Index
-		dc.w ESon_MakeEmeralds-ESon_Index
-		dc.w ESon_Animate-ESon_Index
-		dc.w ESon_LookUp-ESon_Index
-		dc.w ESon_ClrObjRam-ESon_Index
-		dc.w ESon_Animate-ESon_Index
-		dc.w ESon_MakeLogo-ESon_Index
-		dc.w ESon_Animate-ESon_Index
-		dc.w ESon_Leap-ESon_Index
-		dc.w ESon_Animate-ESon_Index
+ESon_Index:	offsetTable
+		ptr ESon_Main
+		ptr ESon_MakeEmeralds
+		ptr ESon_Animate
+		ptr ESon_LookUp
+		ptr ESon_ClrObjRam
+		ptr ESon_Animate
+		ptr ESon_MakeLogo
+		ptr ESon_Animate
+		ptr ESon_Leap
+		ptr ESon_Animate
 
 eson_time = objoff_30	; time to wait between events
 ; ===========================================================================
@@ -133,8 +134,9 @@ EndChaos:
 		jsr	ECha_Index(pc,d1.w)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-ECha_Index:	dc.w ECha_Main-ECha_Index
-		dc.w ECha_Move-ECha_Index
+ECha_Index:	offsetTable
+		ptr ECha_Main
+		ptr ECha_Move
 
 echa_origX:	equ objoff_38	; x-axis centre of emerald circle (2 bytes)
 echa_origY:	equ objoff_3A	; y-axis centre of emerald circle (2 bytes)
@@ -224,9 +226,10 @@ EndSTH:
 		jmp	(DisplaySprite).l
 	endif
 ; ===========================================================================
-ESth_Index:	dc.w ESth_Main-ESth_Index
-		dc.w ESth_Move-ESth_Index
-		dc.w ESth_GotoCredits-ESth_Index
+ESth_Index:	offsetTable
+		ptr ESth_Main
+		ptr ESth_Move
+		ptr ESth_GotoCredits
 
 esth_time = objoff_30		; time until exit
 ; ===========================================================================

--- a/_incObj/8A Credits.asm
+++ b/_incObj/8A Credits.asm
@@ -8,8 +8,9 @@ CreditsText:
 		move.w	Cred_Index(pc,d0.w),d1
 		jmp	Cred_Index(pc,d1.w)
 ; ===========================================================================
-Cred_Index:	dc.w Cred_Main-Cred_Index
-		dc.w Cred_Display-Cred_Index
+Cred_Index:	offsetTable
+		ptr Cred_Main
+		ptr Cred_Display
 ; ===========================================================================
 
 Cred_Main:	; Routine 0

--- a/_incObj/8B & 8C Try Again, End Eggman, End Emeralds.asm
+++ b/_incObj/8B & 8C Try Again, End Eggman, End Emeralds.asm
@@ -9,10 +9,11 @@ EndEggman:
 		jsr	EEgg_Index(pc,d1.w)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-EEgg_Index:	dc.w EEgg_Main-EEgg_Index
-		dc.w EEgg_Animate-EEgg_Index
-		dc.w EEgg_Juggle-EEgg_Index
-		dc.w EEgg_Wait-EEgg_Index
+EEgg_Index:	offsetTable
+		ptr EEgg_Main
+		ptr EEgg_Animate
+		ptr EEgg_Juggle
+		ptr EEgg_Wait
 
 eegg_time = objoff_30		; time between juggle motions
 ; ===========================================================================
@@ -84,8 +85,9 @@ TryChaos:
 		jsr	TCha_Index(pc,d1.w)
 		jmp	(DisplaySprite).l
 ; ===========================================================================
-TCha_Index:	dc.w TCha_Main-TCha_Index
-		dc.w TCha_Move-TCha_Index
+TCha_Index:	offsetTable
+		ptr TCha_Main
+		ptr TCha_Move
 ; ===========================================================================
 
 TCha_Main:	; Routine 0

--- a/_incObj/DebugMode.asm
+++ b/_incObj/DebugMode.asm
@@ -8,8 +8,9 @@ DebugMode:
 		move.w	Debug_Index(pc,d0.w),d1
 		jmp	Debug_Index(pc,d1.w)
 ; ===========================================================================
-Debug_Index:	dc.w Debug_Main-Debug_Index
-		dc.w Debug_Action-Debug_Index
+Debug_Index:	offsetTable
+		ptr Debug_Main
+		ptr Debug_Action
 ; ===========================================================================
 
 Debug_Main:	; Routine 0

--- a/sonic.asm
+++ b/sonic.asm
@@ -539,17 +539,18 @@ ShowErrorMessage:
 ; End of function ShowErrorMessage
 ; ===========================================================================
 
-ErrorText:	dc.w .exception-ErrorText
-		dc.w .bus-ErrorText
-		dc.w .address-ErrorText
-		dc.w .illinstruct-ErrorText
-		dc.w .zerodivide-ErrorText
-		dc.w .chkinstruct-ErrorText
-		dc.w .trapv-ErrorText
-		dc.w .privilege-ErrorText
-		dc.w .trace-ErrorText
-		dc.w .line1010-ErrorText
-		dc.w .line1111-ErrorText
+ErrorText:	offsetTable
+		ptr .exception
+		ptr .bus
+		ptr .address
+		ptr .illinstruct
+		ptr .zerodivide
+		ptr .chkinstruct
+		ptr .trapv
+		ptr .privilege
+		ptr .trace
+		ptr .line1010
+		ptr .line1111
 
 .exception:	dc.b "ERROR EXCEPTION    "
 .bus:		dc.b "BUS ERROR          "
@@ -666,19 +667,20 @@ VBlank_Exit:
 
 ; ===========================================================================
 ; VBla_Index:
-VBlank_Index:	dc.w VBlank_Lag-VBlank_Index		; $00 - (lag frame)
-		dc.w VBlank_Sega-VBlank_Index		; $02 - Sega Screen
-		dc.w VBlank_Title-VBlank_Index		; $04 - Title Screen, Credits, Try Again
-		dc.w VBlank_Unused06-VBlank_Index	; $06 - (unused)
-		dc.w VBlank_Levels-VBlank_Index		; $08 - Levels, Demos
-		dc.w VBlank_SpecialStage-VBlank_Index	; $0A - Special Stages
-		dc.w VBlank_TitleCards-VBlank_Index	; $0C - Title Cards
-		dc.w VBlank_Unused0E-VBlank_Index	; $0E - (unused)
-		dc.w VBlank_Paused-VBlank_Index		; $10 - Paused
-		dc.w VBlank_PaletteFade-VBlank_Index	; $12 - Palette Fade
-		dc.w VBlank_SegaPCM-VBlank_Index	; $14 - Sega Screen PCM
-		dc.w VBlank_Continue-VBlank_Index	; $16 - Continue Screen, SS Finish
-		dc.w VBlank_Ending-VBlank_Index		; $18 - Ending Sequence
+VBlank_Index:	offsetTable
+		ptr VBlank_Lag		; $00 - (lag frame)
+		ptr VBlank_Sega		; $02 - Sega Screen
+		ptr VBlank_Title	; $04 - Title Screen, Credits, Try Again
+		ptr VBlank_Unused06	; $06 - (unused)
+		ptr VBlank_Levels	; $08 - Levels, Demos
+		ptr VBlank_SpecialStage	; $0A - Special Stages
+		ptr VBlank_TitleCards	; $0C - Title Cards
+		ptr VBlank_Unused0E	; $0E - (unused)
+		ptr VBlank_Paused	; $10 - Paused
+		ptr VBlank_PaletteFade	; $12 - Palette Fade
+		ptr VBlank_SegaPCM	; $14 - Sega Screen PCM
+		ptr VBlank_Continue	; $16 - Continue Screen, SS Finish
+		ptr VBlank_Ending	; $18 - Ending Sequence
 ; ===========================================================================
 
 ; ===========================================================================
@@ -4971,43 +4973,44 @@ Art_SbzSmoke:	binclude	"artunc/SBZ Background Smoke.bin"
 ; Level layout index
 ; Format: foreground, background, leftover/unused
 ; ---------------------------------------------------------------------------
-Level_Index:
-		; GHZ
-		dc.w Level_GHZ1-Level_Index, Level_GHZbg-Level_Index, Level_GHZ1Unk-Level_Index
-		dc.w Level_GHZ2-Level_Index, Level_GHZbg-Level_Index, Level_GHZ2Unk-Level_Index
-		dc.w Level_GHZ3-Level_Index, Level_GHZbg-Level_Index, Level_GHZ3Unk-Level_Index
-		dc.w Level_GHZ4Unk-Level_Index, Level_GHZ4Unk-Level_Index, Level_GHZ4Unk-Level_Index
-		; LZ
-		dc.w Level_LZ1-Level_Index, Level_LZbg-Level_Index, Level_LZ1Unk-Level_Index
-		dc.w Level_LZ2-Level_Index, Level_LZbg-Level_Index, Level_LZ2Unk-Level_Index
-		dc.w Level_LZ3-Level_Index, Level_LZbg-Level_Index, Level_LZ3Unk-Level_Index
-		dc.w Level_SBZ3-Level_Index, Level_LZbg-Level_Index, Level_SBZ3Unk-Level_Index
-		; MZ
-		dc.w Level_MZ1-Level_Index, Level_MZ1bg-Level_Index, Level_MZ1-Level_Index
-		dc.w Level_MZ2-Level_Index, Level_MZ2bg-Level_Index, Level_MZ2Unk-Level_Index
-		dc.w Level_MZ3-Level_Index, Level_MZ3bg-Level_Index, Level_MZ3Unk-Level_Index
-		dc.w Level_MZ4Unk-Level_Index, Level_MZ4Unk-Level_Index, Level_MZ4Unk-Level_Index
-		; SLZ
-		dc.w Level_SLZ1-Level_Index, Level_SLZbg-Level_Index, Level_SLZ1Unk-Level_Index
-		dc.w Level_SLZ2-Level_Index, Level_SLZbg-Level_Index, Level_SLZ1Unk-Level_Index
-		dc.w Level_SLZ3-Level_Index, Level_SLZbg-Level_Index, Level_SLZ1Unk-Level_Index
-		dc.w Level_SLZ1Unk-Level_Index, Level_SLZ1Unk-Level_Index, Level_SLZ1Unk-Level_Index
-		; SYZ
-		dc.w Level_SYZ1-Level_Index, Level_SYZbg-Level_Index, Level_SYZ1Unk-Level_Index
-		dc.w Level_SYZ2-Level_Index, Level_SYZbg-Level_Index, Level_SYZ2Unk-Level_Index
-		dc.w Level_SYZ3-Level_Index, Level_SYZbg-Level_Index, Level_SYZ3Unk-Level_Index
-		dc.w Level_SYZ4Unk-Level_Index, Level_SYZ4Unk-Level_Index, Level_SYZ4Unk-Level_Index
-		; SBZ
-		dc.w Level_SBZ1-Level_Index, Level_SBZ1bg-Level_Index, Level_SBZ1bg-Level_Index
-		dc.w Level_SBZ2-Level_Index, Level_SBZ2bg-Level_Index, Level_SBZ2bg-Level_Index
-		dc.w Level_SBZ2-Level_Index, Level_SBZ2bg-Level_Index, Level_SBZ2Unk-Level_Index
-		dc.w Level_SBZ4Unk-Level_Index, Level_SBZ4Unk-Level_Index, Level_SBZ4Unk-Level_Index
+Level_Index:	offsetTable
+		ptr	Level_GHZ1,	Level_GHZbg,	Level_GHZ1Unk	; GHZ1
+		ptr	Level_GHZ2,	Level_GHZbg,	Level_GHZ2Unk	; GHZ2
+		ptr	Level_GHZ3,	Level_GHZbg,	Level_GHZ3Unk	; GHZ3
+		ptr	Level_GHZ4Unk,	Level_GHZ4Unk,	Level_GHZ4Unk	; GHZ4 (unused)
+
+		ptr	Level_LZ1,	Level_LZbg,	Level_LZ1Unk	; LZ1
+		ptr	Level_LZ2,	Level_LZbg,	Level_LZ2Unk	; LZ2
+		ptr	Level_LZ3,	Level_LZbg,	Level_LZ3Unk	; LZ3
+		ptr	Level_SBZ3,	Level_LZbg,	Level_SBZ3Unk	; LZ4 (Scrap Brain Zone act 3)
+
+		ptr	Level_MZ1,	Level_MZ1bg,	Level_MZ1	; MZ1
+		ptr	Level_MZ2,	Level_MZ2bg,	Level_MZ2Unk	; MZ2
+		ptr	Level_MZ3,	Level_MZ3bg,	Level_MZ3Unk	; MZ3
+		ptr	Level_MZ4Unk,	Level_MZ4Unk,	Level_MZ4Unk	; MZ4 (unused)
+
+		ptr	Level_SLZ1,	Level_SLZbg,	Level_SLZ1Unk	; SLZ1
+		ptr	Level_SLZ2,	Level_SLZbg,	Level_SLZ1Unk	; SLZ2
+		ptr	Level_SLZ3,	Level_SLZbg,	Level_SLZ1Unk	; SLZ3
+		ptr	Level_SLZ1Unk,	Level_SLZ1Unk,	Level_SLZ1Unk	; SLZ4 (unused)
+
+		ptr	Level_SYZ1,	Level_SYZbg,	Level_SYZ1Unk	; SYZ1
+		ptr	Level_SYZ2,	Level_SYZbg,	Level_SYZ2Unk	; SYZ2
+		ptr	Level_SYZ3,	Level_SYZbg,	Level_SYZ3Unk	; SYZ3
+		ptr	Level_SYZ4Unk,	Level_SYZ4Unk,	Level_SYZ4Unk	; SYZ4 (unused)
+
+		ptr	Level_SBZ1,	Level_SBZ1bg,	Level_SBZ1bg	; SBZ1
+		ptr	Level_SBZ2,	Level_SBZ2bg,	Level_SBZ2bg	; SBZ2
+		ptr	Level_SBZ2,	Level_SBZ2bg,	Level_SBZ2Unk	; SBZ3 (Final Zone)
+		ptr	Level_SBZ4Unk,	Level_SBZ4Unk,	Level_SBZ4Unk	; SBZ4 (unused)
+
 		zonewarning Level_Index,24
-		; Ending
-		dc.w Level_End-Level_Index, Level_GHZbg-Level_Index, Level_EndUnk-Level_Index
-		dc.w Level_End-Level_Index, Level_GHZbg-Level_Index, Level_EndUnk-Level_Index
-		dc.w Level_EndUnk-Level_Index, Level_EndUnk-Level_Index, Level_EndUnk-Level_Index
-		dc.w Level_EndUnk-Level_Index, Level_EndUnk-Level_Index, Level_EndUnk-Level_Index
+
+		ptr	Level_End,	Level_GHZbg,	Level_EndUnk	; good ending
+		ptr	Level_End,	Level_GHZbg,	Level_EndUnk	; bad ending
+		ptr	Level_EndUnk,	Level_EndUnk,	Level_EndUnk	; (unused)
+		ptr	Level_EndUnk,	Level_EndUnk,	Level_EndUnk	; (unused)
+
 
 Level_GHZ1:	binclude	"levels/ghz1.bin"
 		even
@@ -5111,57 +5114,62 @@ Art_BigRing:	binclude	"artunc/Giant Ring.bin"
 	endif
 	
 ; ---------------------------------------------------------------------------
-; Sprite locations index
+; Level object locations index
 ; ---------------------------------------------------------------------------
-ObjPos_Index:
-		; GHZ
-		dc.w ObjPos_GHZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_GHZ2-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_GHZ3-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_GHZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		; LZ
-		dc.w ObjPos_LZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_LZ2-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_LZ3-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_SBZ3-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		; MZ
-		dc.w ObjPos_MZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_MZ2-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_MZ3-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_MZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		; SLZ
-		dc.w ObjPos_SLZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_SLZ2-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_SLZ3-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_SLZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		; SYZ
-		dc.w ObjPos_SYZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_SYZ2-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_SYZ3-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_SYZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		; SBZ
-		dc.w ObjPos_SBZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_SBZ2-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_FZ-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_SBZ1-ObjPos_Index, ObjPos_Null-ObjPos_Index
+ObjPos_Index:	offsetTable
+		ptr	ObjPos_GHZ1,	ObjPos_Null	; GHZ1
+		ptr	ObjPos_GHZ2,	ObjPos_Null	; GHZ2
+		ptr	ObjPos_GHZ3,	ObjPos_Null	; GHZ3
+		ptr	ObjPos_GHZ1,	ObjPos_Null	; GHZ4 (unused)
+
+		ptr	ObjPos_LZ1,	ObjPos_Null	; LZ1
+		ptr	ObjPos_LZ2,	ObjPos_Null	; LZ2
+		ptr	ObjPos_LZ3,	ObjPos_Null	; LZ3
+		ptr	ObjPos_SBZ3,	ObjPos_Null	; LZ4 (Scrap Brain Zone act 3)
+
+		ptr	ObjPos_MZ1,	ObjPos_Null	; MZ1
+		ptr	ObjPos_MZ2,	ObjPos_Null	; MZ2
+		ptr	ObjPos_MZ3,	ObjPos_Null	; MZ3
+		ptr	ObjPos_MZ1,	ObjPos_Null	; MZ4 (unused)
+
+		ptr	ObjPos_SLZ1,	ObjPos_Null	; SLZ1
+		ptr	ObjPos_SLZ2,	ObjPos_Null	; SLZ2
+		ptr	ObjPos_SLZ3,	ObjPos_Null	; SLZ3
+		ptr	ObjPos_SLZ1,	ObjPos_Null	; SLZ4 (unused)
+
+		ptr	ObjPos_SYZ1,	ObjPos_Null	; SYZ1
+		ptr	ObjPos_SYZ2,	ObjPos_Null	; SYZ2
+		ptr	ObjPos_SYZ3,	ObjPos_Null	; SYZ3
+		ptr	ObjPos_SYZ1,	ObjPos_Null	; SYZ4 (unused)
+
+		ptr	ObjPos_SBZ1,	ObjPos_Null	; SBZ1
+		ptr	ObjPos_SBZ2,	ObjPos_Null	; SBZ2
+		ptr	ObjPos_FZ,	ObjPos_Null	; SBZ3 (Final Zone)
+		ptr	ObjPos_SBZ1,	ObjPos_Null	; SBZ4 (unused)
+
 		zonewarning ObjPos_Index,$10
-		; Ending
-		dc.w ObjPos_End-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_End-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_End-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		dc.w ObjPos_End-ObjPos_Index, ObjPos_Null-ObjPos_Index
-		; --- Put extra object data here. ---
+
+		ptr	ObjPos_End,	ObjPos_Null	; good ending
+		ptr	ObjPos_End,	ObjPos_Null	; bad ending
+		ptr	ObjPos_End,	ObjPos_Null	; (unused)
+		ptr	ObjPos_End,	ObjPos_Null	; (unused)
+
+		; --- Put extra object data here... ---
+
 ObjPosLZPlatform_Index:
-		dc.w ObjPos_LZ1pf1-ObjPos_Index, ObjPos_LZ1pf2-ObjPos_Index
-		dc.w ObjPos_LZ2pf1-ObjPos_Index, ObjPos_LZ2pf2-ObjPos_Index
-		dc.w ObjPos_LZ3pf1-ObjPos_Index, ObjPos_LZ3pf2-ObjPos_Index
-		dc.w ObjPos_LZ1pf1-ObjPos_Index, ObjPos_LZ1pf2-ObjPos_Index
+		ptr	ObjPos_LZ1pf1,	ObjPos_LZ1pf2
+		ptr	ObjPos_LZ2pf1,	ObjPos_LZ2pf2
+		ptr	ObjPos_LZ3pf1,	ObjPos_LZ3pf2
+		ptr	ObjPos_LZ1pf1,	ObjPos_LZ1pf2
+
 ObjPosSBZPlatform_Index:
-		dc.w ObjPos_SBZ1pf1-ObjPos_Index, ObjPos_SBZ1pf2-ObjPos_Index
-		dc.w ObjPos_SBZ1pf3-ObjPos_Index, ObjPos_SBZ1pf4-ObjPos_Index
-		dc.w ObjPos_SBZ1pf5-ObjPos_Index, ObjPos_SBZ1pf6-ObjPos_Index
-		dc.w ObjPos_SBZ1pf1-ObjPos_Index, ObjPos_SBZ1pf2-ObjPos_Index
-		dc.b $FF, $FF, 0, 0, 0,	0
+		ptr	ObjPos_SBZ1pf1,	ObjPos_SBZ1pf2
+		ptr	ObjPos_SBZ1pf3,	ObjPos_SBZ1pf4
+		ptr	ObjPos_SBZ1pf5,	ObjPos_SBZ1pf6
+		ptr	ObjPos_SBZ1pf1,	ObjPos_SBZ1pf2
+
+
+ObjPos_PreNull:	dc.b $FF, $FF, 0, 0, 0,	0
 
 ObjPos_GHZ1:	binclude	"objpos/ghz1.bin"
 		even


### PR DESCRIPTION
Ported straight from the Sonic 2 disassembly, although I've also added a shorthand `ptr` macro because I personally find `offsetTableEntry.w` pretty wordy (and it's always word-sized anyway). It internally still uses that macro though, so it should still make porting stuff from Sonic 2 less of a hassle going forward.