### PR TITLE
Fully documented BuildSprites

### DIFF
--- a/_Constants.asm
+++ b/_Constants.asm
@@ -57,8 +57,9 @@ vram_hscroll:	equ $FC00	; horizontal scroll table
 
 ; Sprite data
 sprites_max:		equ 80		; maximum number of sprites the Mega Drive can handle
-spritequeue_layernum:	equ 1<<3	; =8 sprite priority layers (must be a power of 2)
-spritequeue_layersize:	equ 1<<7	; =$80 (2 bytes entry counter + $7E bytes to store entries) (must be a power of 2)
+spritelayer_num:	equ 1<<3	; =8 sprite priority layers (must be a power of 2)
+spritelayer_size_bits:	equ 7		; layer size must be a power of 2
+spritelayer_size:	equ 1<<spritelayer_size_bits ; =$80 (2 bytes entry counter + $7E bytes to store entries)
 spritetable_entrysize:	equ 8		; 8 bytes per linked sprite table entry (2 y-pos + 1 size + 1 link + 2 VRAM + 2 x-pos)
 
 ; Various sizes

--- a/_Constants.asm
+++ b/_Constants.asm
@@ -57,11 +57,8 @@ vram_hscroll:	equ $FC00	; horizontal scroll table
 
 ; Sprite data
 sprites_max:		equ 80		; maximum number of sprites the Mega Drive can handle
-sprites_basepos:	equ 128		; 128px donut around the visible Mega Drive screen space
-spritequeue_layers:	equ 8		; 8 sprite priority layers
-spritequeue_counter:	equ 2		; 2 bytes entry counter at start of each layer (value is x2)
-spritequeue_entries:	equ $7E		; $7E bytes to store entires in a layer (2 bytes per entry)
-spritequeue_layersize:	equ spritequeue_counter+spritequeue_entries ; $80 bytes per sprite priority layer
+spritequeue_layernum:	equ 8		; 8 sprite priority layers
+spritequeue_layersize:	equ 2+$7E	; =$80 (2 bytes entry counter + $7E bytes to store entries)
 spritetable_entrysize:	equ 8		; 8 bytes per linked sprite table entry (2 y-pos + 1 size + 1 link + 2 VRAM + 2 x-pos)
 
 ; Various sizes

--- a/_Constants.asm
+++ b/_Constants.asm
@@ -55,6 +55,15 @@ vram_bg:	equ $E000	; background namespace
 vram_sprites:	equ $F800	; sprite table
 vram_hscroll:	equ $FC00	; horizontal scroll table
 
+; Sprite data
+sprites_max:		equ 80		; maximum number of sprites the Mega Drive can handle
+sprites_basepos:	equ 128		; 128px donut around the visible Mega Drive screen space
+spritequeue_layers:	equ 8		; 8 sprite priority layers
+spritequeue_counter:	equ 2		; 2 bytes entry counter at start of each layer (value is x2)
+spritequeue_entries:	equ $7E		; $7E bytes to store entires in a layer (2 bytes per entry)
+spritequeue_layersize:	equ spritequeue_counter+spritequeue_entries ; $80 bytes per sprite priority layer
+spritetable_entrysize:	equ 8		; 8 bytes per linked sprite table entry (2 y-pos + 1 size + 1 link + 2 VRAM + 2 x-pos)
+
 ; Various sizes
 tile_size:	equ 8*8/2	; size of a single 8x8 tile
 chunk_size:	equ $200	; size of a single 256x256 chunk

--- a/_Constants.asm
+++ b/_Constants.asm
@@ -57,8 +57,8 @@ vram_hscroll:	equ $FC00	; horizontal scroll table
 
 ; Sprite data
 sprites_max:		equ 80		; maximum number of sprites the Mega Drive can handle
-spritequeue_layernum:	equ 8		; 8 sprite priority layers
-spritequeue_layersize:	equ 2+$7E	; =$80 (2 bytes entry counter + $7E bytes to store entries)
+spritequeue_layernum:	equ 1<<3	; =8 sprite priority layers (must be a power of 2)
+spritequeue_layersize:	equ 1<<7	; =$80 (2 bytes entry counter + $7E bytes to store entries) (must be a power of 2)
 spritetable_entrysize:	equ 8		; 8 bytes per linked sprite table entry (2 y-pos + 1 size + 1 link + 2 VRAM + 2 x-pos)
 
 ; Various sizes

--- a/_Variables.asm
+++ b/_Variables.asm
@@ -23,7 +23,7 @@ v_bgscroll_buffer:	ds.b	$200		; background scroll buffer
 v_ngfx_buffer:		ds.b	$200		; Nemesis graphics decompression buffer
 v_ngfx_buffer_end:
 
-v_spritequeue:		ds.b	spritequeue_layers*spritequeue_layersize ; sprite display queue, in order of priority (8*$80=$400 bytes)
+v_spritequeue:		ds.b	spritequeue_layernum*spritequeue_layersize ; sprite display queue, in order of priority (8*$80=$400 bytes)
 
 v_16x16:		ds.b	$1800		; 16x16 tile mappings
 

--- a/_Variables.asm
+++ b/_Variables.asm
@@ -22,7 +22,9 @@ v_lvllayout_end:
 v_bgscroll_buffer:	ds.b	$200		; background scroll buffer
 v_ngfx_buffer:		ds.b	$200		; Nemesis graphics decompression buffer
 v_ngfx_buffer_end:
-v_spritequeue:		ds.b	$400		; sprite display queue, in order of priority
+
+v_spritequeue:		ds.b	spritequeue_layers*spritequeue_layersize ; sprite display queue, in order of priority (8*$80=$400 bytes)
+
 v_16x16:		ds.b	$1800		; 16x16 tile mappings
 
 v_sgfx_buffer:		ds.b	tile_size*23	; buffered Sonic graphics ($17 cells)
@@ -294,7 +296,7 @@ v_scroll_block_4_size:	ds.w	1		; unused
 			ds.b	8		; unused
 v_levelvariables_end:
 
-v_spritetablebuffer:	ds.b	$280		; sprite table (last $80 bytes are overwritten by v_palette_water_fading)
+v_spritetablebuffer:	ds.b	spritetable_entrysize*sprites_max ; sprite table (8*80=$280 bytes) (last $80 bytes are overwritten by v_palette_water_fading)
 v_spritetablebuffer_end:
 
 v_palette_water_fading = v_spritetablebuffer_end-$80	; duplicate underwater palette, used for transitions ($80 bytes)

--- a/_Variables.asm
+++ b/_Variables.asm
@@ -23,7 +23,7 @@ v_bgscroll_buffer:	ds.b	$200		; background scroll buffer
 v_ngfx_buffer:		ds.b	$200		; Nemesis graphics decompression buffer
 v_ngfx_buffer_end:
 
-v_spritequeue:		ds.b	spritequeue_layernum*spritequeue_layersize ; sprite display queue, in order of priority (8*$80=$400 bytes)
+v_spritequeue:		ds.b	spritelayer_num*spritelayer_size ; sprite display queue, in order of priority (8*$80=$400 bytes)
 
 v_16x16:		ds.b	$1800		; 16x16 tile mappings
 

--- a/_inc/BuildSprites.asm
+++ b/_inc/BuildSprites.asm
@@ -1,278 +1,284 @@
+; ===========================================================================
 ; ---------------------------------------------------------------------------
-; Subroutine to convert mappings (etc) to proper Megadrive sprites
+; Subroutine to convert mappings (etc) to proper Mega Drive sprites
 ; ---------------------------------------------------------------------------
 
-; ===========================================================================
-BldSpr_ScrPos:	dc.l 0				; blank
-		dc.l v_screenposx&$FFFFFF	; main screen x-position
-		dc.l v_bgscreenposx&$FFFFFF	; background x-position 1
-		dc.l v_bg3screenposx&$FFFFFF	; background x-position 2
-; ===========================================================================
+BldSpr_ScrPos:	dc.l 0					; blank
+		dc.l v_screenposx&$FFFFFF		; main screen X-position
+		dc.l v_bgscreenposx&$FFFFFF		; background X-position 1 (unused)
+		dc.l v_bg3screenposx&$FFFFFF		; background X-position 2 (unused)
+
+; ---------------------------------------------------------------------------
 
 BuildSprites:
-		lea	(v_spritetablebuffer).w,a2 ; set address for sprite table
-		moveq	#0,d5
-		lea	(v_spritequeue).w,a4
-		moveq	#7,d7
+		lea	(v_spritetablebuffer).w,a2	; set address for sprite table
+		moveq	#0,d5				; reset sprite counter to 0
+		lea	(v_spritequeue).w,a4		; load sprite queue priority layers
+		moveq	#spritequeue_layers-1,d7	; iterate through all eight layers
 
-	.priorityLoop:
-		tst.w	(a4)	; are there objects left to draw?
-		beq.w	.nextPriority	; if not, branch
-		moveq	#2,d6
+.priorityLoop:
+		tst.w	(a4)				; are there objects left to draw in current priority layer?
+		beq.w	.nextPriority			; if not, go to next priority layer
 
+		moveq	#spritequeue_counter,d6		; initialize offset pointer to first object after entry counter (2 bytes)
 	.objectLoop:
-		movea.w	(a4,d6.w),a0	; load object ID
-		tst.b	(a0)		; if null, branch
-		beq.w	.skipObject
-		bclr	#7,obRender(a0)		; set as not visible
+		movea.w	(a4,d6.w),a0			; load object ID
+		tst.b	(a0)				; has an object been queued for display but deleted?
+		beq.w	.skipObject			; if yes, skip (this appears to be an effort to fix display-and-delete bugs)
+		bclr	#7,obRender(a0)			; set object as not visible
 
-		move.b	obRender(a0),d0
-		move.b	d0,d4
-		andi.w	#$C,d0		; get drawing coordinates
-		beq.s	.screenCoords	; branch if 0 (screen coordinates)
-		movea.l	BldSpr_ScrPos(pc,d0.w),a1
-	; check object bounds
-		moveq	#0,d0
-		move.b	obActWid(a0),d0
-		move.w	obX(a0),d3
-		sub.w	(a1),d3
-		move.w	d3,d1
-		add.w	d0,d1
-		bmi.w	.skipObject	; left edge out of bounds
-		move.w	d3,d1
-		sub.w	d0,d1
-		cmpi.w	#320,d1
-		bge.s	.skipObject	; right edge out of bounds
-		addi.w	#128,d3		; VDP sprites start at 128px
+	; --- Coordinate system ---
+		move.b	obRender(a0),d0			; get object's render flags
+		move.b	d0,d4				; backup for later
+		andi.w	#%1100,d0			; get drawing coordinate system (bit 2-3)
+		beq.s	.screenCoords			; branch if 0 (screen-positioning coordinate system)
+		movea.l	BldSpr_ScrPos(pc,d0.w),a1	; get relative screen position (in practice, only v_screenposx is ever used)
 
-		btst	#4,d4		; is assume height flag on?
-		beq.s	.assumeHeight	; if yes, branch
-		moveq	#0,d0
-		move.b	obHeight(a0),d0
-		move.w	obY(a0),d2
-		sub.w	4(a1),d2
-		move.w	d2,d1
-		add.w	d0,d1
-		bmi.s	.skipObject	; top edge out of bounds
-		move.w	d2,d1
-		sub.w	d0,d1
-		cmpi.w	#224,d1
-		bge.s	.skipObject
-		addi.w	#128,d2		; VDP sprites start at 128px
-		bra.s	.drawObject
-; ===========================================================================
+	; --- Screen bounds check for X-position ---
+		moveq	#0,d0				; clear d0
+		move.b	obActWid(a0),d0			; get object display width
+		move.w	obX(a0),d3			; get object's X-position
+		sub.w	(a1),d3				; subtract relative screen X-position
+		move.w	d3,d1				; remember difference result
+		add.w	d0,d1				; add object display width
+		bmi.w	.skipObject			; if underflowed, left edge is out of bounds
+		move.w	d3,d1				; restore difference result
+		sub.w	d0,d1				; subtract object display width
+		cmpi.w	#320,d1				; is result greater than the screen width? (320px)
+		bge.s	.skipObject			; if yes, right edge is out of bounds
+		addi.w	#sprites_basepos,d3		; VDP sprites start at 128px
+
+	; --- Screen bounds check for Y-position ---
+		btst	#4,d4				; is custom height flag set?
+		beq.s	.assumeHeight			; if not, assume height instead
+
+		moveq	#0,d0				; clear d0
+		move.b	obHeight(a0),d0			; get custom object height
+		move.w	obY(a0),d2			; get object's Y-position
+		sub.w	4(a1),d2			; subtract relative screen Y-position
+		move.w	d2,d1				; remember result
+		add.w	d0,d1				; add object display height
+		bmi.s	.skipObject			; if underflowed, top edge is out of bounds
+		move.w	d2,d1				; restore difference result
+		sub.w	d0,d1				; subtract object display height
+		cmpi.w	#224,d1				; is result greater than the screen height? (224px)
+		bge.s	.skipObject			; if yes, bottom edge is out of bounds
+		addi.w	#sprites_basepos,d2		; VDP sprites start at 128px
+		bra.s	.drawObject			; skip over
+; ---------------------------------------------------------------------------
 
 	.screenCoords:
-		move.w	obScreenY(a0),d2	; special variable for screen Y
-		move.w	obX(a0),d3
-		bra.s	.drawObject
-; ===========================================================================
+		move.w	obScreenY(a0),d2		; special variable for screen Y
+		move.w	obX(a0),d3			; get object's X-position
+		bra.s	.drawObject			; skip over
+; ---------------------------------------------------------------------------
 
 	.assumeHeight:
-		move.w	obY(a0),d2
-		sub.w	4(a1),d2
-		addi.w	#$80,d2
-		cmpi.w	#$60,d2
-		blo.s	.skipObject
-		cmpi.w	#$180,d2
-		bhs.s	.skipObject
+		.ah:	equ 32				; assumed height is 32px ($20)
+		move.w	obY(a0),d2			; get object's Y-position
+		sub.w	4(a1),d2			; subtract relative screen Y-position (v_screenposy)
+		addi.w	#sprites_basepos,d2		; VDP sprites start at 128px
+		cmpi.w	#sprites_basepos-.ah,d2		; is top Y-position more than 32px out of bounds?
+		blo.s	.skipObject			; if yes, assumed height top edge is out of bounds
+		cmpi.w	#sprites_basepos+224+.ah,d2	; is bottom Y-position more than 32px out of bounds?
+		bhs.s	.skipObject			; if yes, assumed height bottom edge is out of bounds
 
+	; --- Load sprite mappings ---
 	.drawObject:
-		movea.l	obMap(a0),a1
-		moveq	#0,d1
-		btst	#5,d4		; is static mappings flag on?
-		bne.s	.drawFrame	; if yes, branch
-		move.b	obFrame(a0),d1
-		add.b	d1,d1
-		adda.w	(a1,d1.w),a1	; get mappings frame address
-		move.b	(a1)+,d1	; number of sprite pieces
-		subq.b	#1,d1
-		bmi.s	.setVisible
+		movea.l	obMap(a0),a1			; get absolute object mappings pointer
 
+		moveq	#1-1,d1				; write only one sprite for raw-mappings
+		btst	#5,d4				; is "raw-mappings" flag on?
+		bne.s	.drawFrame			; if yes, branch (assume mappings point to a single sprite piece)
+
+		move.b	obFrame(a0),d1			; get current object frame ID
+		add.b	d1,d1				; double it for word-based indexing
+		adda.w	(a1,d1.w),a1			; get mappings frame address
+		move.b	(a1)+,d1			; get number of sprite pieces in frame
+		subq.b	#1,d1				; subtract 1 for dbf
+		bmi.s	.setVisible			; if result underflowed, this is was blank frame mapping, branch
+
+	; --- Do the actual sprite mapping rendering ---
 	.drawFrame:
-		bsr.w	BuildSpr_Draw	; write data from sprite pieces to buffer
+		bsr.w	BuildSpr_Draw			; write data from sprite pieces to buffer, potentially flipped
 
 	.setVisible:
-		bset	#7,obRender(a0)		; set object as visible
+		bset	#7,obRender(a0)			; set object as visible
 
 	.skipObject:
-		addq.w	#2,d6
-		subq.w	#2,(a4)			; number of objects left
-		bne.w	.objectLoop
+		addq.w	#2,d6				; advance to next entry in sprite priority layer
+		subq.w	#2,(a4)				; decrement number of objects left in sprite priority layer
+		bne.w	.objectLoop			; if more objects are left to render, loop
 
-	.nextPriority:
-		lea	$80(a4),a4
-		dbf	d7,.priorityLoop
-		move.b	d5,(v_spritecount).w
-		cmpi.b	#$50,d5
-		beq.s	.spriteLimit
-		move.l	#0,(a2)
-		rts
-; ===========================================================================
+.nextPriority:
+		lea	spritequeue_layersize(a4),a4	; advance to next sprite priority layer (each layer is $80 bytes)
+		dbf	d7,.priorityLoop		; loop for all 8 layers
+
+		move.b	d5,(v_spritecount).w		; write total number of rendered sprites to debug value
+
+		cmpi.b	#sprites_max,d5			; check sprite limit (Mega Drive can only handle 80 at a time)
+	if FixBugs
+		bhs.s	.spriteLimit			; if all sprite slots are taken up (or more), abort process
+	else
+		; See notes below.
+		beq.s	.spriteLimit			; if all sprite slots are taken up (exactly), abort process
+	endif
+
+		move.l	#0,(a2)				; unlink last sprite
+		rts					; return
+; ---------------------------------------------------------------------------
 
 	.spriteLimit:
-		move.b	#0,-5(a2)	; set last sprite link
-		rts
+		move.b	#0,-5(a2)			; unlink penultimate sprite
+		rts					; return
 ; End of function BuildSprites
+
+
 ; ===========================================================================
+; ---------------------------------------------------------------------------
+; Each sprite piece is exactly 5 bytes long. Broken down into bits,
+; they have the format "TTTTTTTT ----WWHH PCCYXAAA AAAAAAAA LLLLLLLL":
+; 
+; Value | Size    | Description
+; -----------------------------
+; T     | Byte    | Top relative coordinate of where the piece appears
+; -     | 4 bits  | Always null/unused
+; W     | 2 bits  | Width of the piece, in tiles minus one:
+;       |         |   0 => 8 pixels wide
+;       |         |   1 => 16 pixels wide
+;       |         |   2 => 24 pixels wide
+;       |         |   3 => 32 pixels wide
+; H     | 2 bits  | Height of the piece, in the same format as the width WW
+; P     | 1 bit   | Priority flag. If set, the piece will appear above everything else
+; C     | 2 bits  | Palette line number
+; X     | 1 bit   | X-flip-flag. If set, the piece will be flipped horizontally
+; Y     | 1 bit   | Y-flip-flag. If set, the piece will be flipped vertically
+; A     | 11 bits | Relative art tile index, spread across two bytes
+; L     | Byte    | Left relative coordinate of where the piece appears
+; ---------------------------------------------------------------------------
+; ===========================================================================
+; ---------------------------------------------------------------------------
+; Macro for BuildSpr_Draw, to visualize the differences between the flips.
+; All four variants work on the same basic principle, only coming with
+; modifications for the flipping.
+; 
+; input:
+;	d1 = number of sprite pieces in mapping minus 1
+;	d2 = base Y-position
+;	d3 = base X-position
+;	d5 = total rendered sprites so far (max 80)
+;	a1 = pointer to starting sprite piece in sprite mappings (see breakdown above)
+;	a2 = pointer to sprite link buffer (v_spritetablebuffer)
+;	a3 = art tile / VRAM setting (obGfx)
+;
+; 	uses d0.w, d4.w
+; ---------------------------------------------------------------------------
+
+buildsprite:	macro xflip,yflip
+
+.loopSpritePieces:
+	; --- Sprite limit check ---
+		cmpi.b	#sprites_max,d5			; check sprite limit (Mega Drive can only handle 80 at a time)
+	if FixBugs
+		bhs.s	.return				; if all sprite slots are taken up (or more), abort process
+	else
+		; This checks if the sprite buffer contains EXACTLY 80 entries, but
+		; it will still continue should it somehow end up with MORE, which
+		; is very dangerous. The above fix introduces no additional overhead.
+		beq.s	.return				; if all sprite slots are taken up (exactly), abort process
+	endif
+
+	; --- Y-position ---
+		move.b	(a1)+,d0			; get relative y-offset
+		if yflip
+			move.b	(a1),d4			; get width and height dimensions of sprite piece (WWHH)
+			ext.w	d0			; extend y-offset to word
+			neg.w	d0			; negate y-offset
+			lsl.b	#3,d4			; multiply height dimension (HH) to multiple of 8px
+			andi.w	#%11000,d4		; mask out non-height bits
+			addq.w	#8,d4			; account of HH=0 being treated as a single 8px tile
+			sub.w	d4,d0			; subtract result from negated Y position to get flipped Y position
+		else
+			ext.w	d0			; extend y-offset to word
+		endif
+		add.w	d2,d0				; add base Y-position
+		move.w	d0,(a2)+			; write to buffer
+
+	; --- Sprite width/height ---
+		if xflip
+			move.b	(a1)+,d4		; get width and height dimensions of sprite piece (backup for later)
+			move.b	d4,(a2)+		; write dimension
+		else
+			move.b	(a1)+,(a2)+		; write width and height dimensions of sprite piece
+		endif
+
+	; --- Sprite link ---
+		addq.b	#1,d5				; increase total sprites counter
+		move.b	d5,(a2)+			; set sprites counter as sprite link
+
+	; --- VRAM settings / art tile / flipping ---
+		move.b	(a1)+,d0			; get first half of VRAM settings (flag and three bits of tile offset)
+		lsl.w	#8,d0				; shift it to upper byte
+		move.b	(a1)+,d0			; get second half of VRAM settings (remaining eight bits of tile offset)
+		add.w	a3,d0				; add base art tile offset of object
+		if xflip|yflip
+			eori.w	#xflip<<11|yflip<<12,d0	; toggle X-flip ($800) and/or Y-flip ($1000) in VDP
+		endif
+		move.w	d0,(a2)+			; write sprite art tile and flags to buffer
+
+	; --- X-position ---
+		move.b	(a1)+,d0			; get relative x-offset
+		ext.w	d0				; extend x-offset to word
+		if xflip
+			neg.w	d0			; negate x-offset
+			add.b	d4,d4			; multiply width dimension (WW) to multiple of 8px
+			andi.w	#%11000,d4		; mask out non-width bits
+			addq.w	#8,d4			; account of WW=0 being treated as a single 8px tile
+			sub.w	d4,d0			; subtract result from negated X-position to get flipped X-position
+		endif
+		add.w	d3,d0				; add X-position
+		andi.w	#$1FF,d0			; keep within 512px (screen wrap)
+		bne.s	.x				; is X-position zero? if not, branch
+		addq.w	#1,d0				; force non-zero X-position to avoid unwanted sprite masking
+	.x:	move.w	d0,(a2)+			; write to buffer
+
+	; --- Loop for all pieces in mapping ---
+		dbf	d1,.loopSpritePieces		; process next sprite piece
+
+	.return:
+		rts					; sprite rendering for this object done
+
+	endm
+
+
+; ---------------------------------------------------------------------------
+; Subroutine to convert a object mapping frame (with multiple sprite pieces)
+; into valid, linked Mega Drive sprites and buffer them, with flipping.
+; ---------------------------------------------------------------------------
 
 BuildSpr_Draw:
-		movea.w	obGfx(a0),a3
-		btst	#0,d4
-		bne.s	BuildSpr_FlipX
-		btst	#1,d4
-		bne.w	BuildSpr_FlipY
-; End of function BuildSpr_Draw
-; ===========================================================================
+		movea.w	obGfx(a0),a3			; get art tile / VRAM settings for object
+
+		btst	#0,d4				; is X-flip flag set?
+		bne.s	BuildSpr_FlipX			; if yes, branch
+		btst	#1,d4				; is Y-flip flag set?
+		bne.w	BuildSpr_FlipY			; if yes, branch
 
 BuildSpr_Normal:
-		cmpi.b	#$50,d5		; check sprite limit
-		beq.s	.return
-		move.b	(a1)+,d0	; get y-offset
-		ext.w	d0
-		add.w	d2,d0		; add y-position
-		move.w	d0,(a2)+	; write to buffer
-		move.b	(a1)+,(a2)+	; write sprite size
-		addq.b	#1,d5		; increase sprite counter
-		move.b	d5,(a2)+	; set as sprite link
-		move.b	(a1)+,d0	; get art tile
-		lsl.w	#8,d0
-		move.b	(a1)+,d0
-		add.w	a3,d0		; add art tile offset
-		move.w	d0,(a2)+	; write to buffer
-		move.b	(a1)+,d0	; get x-offset
-		ext.w	d0
-		add.w	d3,d0		; add x-position
-		andi.w	#$1FF,d0	; keep within 512px
-		bne.s	.writeX
-		addq.w	#1,d0
-
-	.writeX:
-		move.w	d0,(a2)+	; write to buffer
-		dbf	d1,BuildSpr_Normal	; process next sprite piece
-
-	.return:
-		rts
-; End of function BuildSpr_Normal
-
-; ===========================================================================
+		buildsprite	0,0			; draw sprite (no X-flip or Y-flip)
+; ---------------------------------------------------------------------------
 
 BuildSpr_FlipX:
-		btst	#1,d4		; is object also y-flipped?
-		bne.w	BuildSpr_FlipXY	; if yes, branch
+		btst	#1,d4				; is object Y-flipped as well?
+		bne.w	BuildSpr_FlipXY			; if yes, branch
 
-	.loop:
-		cmpi.b	#$50,d5		; check sprite limit
-		beq.s	.return
-		move.b	(a1)+,d0	; y position
-		ext.w	d0
-		add.w	d2,d0
-		move.w	d0,(a2)+
-		move.b	(a1)+,d4	; size
-		move.b	d4,(a2)+	
-		addq.b	#1,d5		; link
-		move.b	d5,(a2)+
-		move.b	(a1)+,d0	; art tile
-		lsl.w	#8,d0
-		move.b	(a1)+,d0	
-		add.w	a3,d0
-		eori.w	#$800,d0	; toggle flip-x in VDP
-		move.w	d0,(a2)+	; write to buffer
-		move.b	(a1)+,d0	; get x-offset
-		ext.w	d0
-		neg.w	d0			; negate it
-		add.b	d4,d4		; calculate flipped position by size
-		andi.w	#$18,d4
-		addq.w	#8,d4
-		sub.w	d4,d0
-		add.w	d3,d0
-		andi.w	#$1FF,d0	; keep within 512px
-		bne.s	.writeX
-		addq.w	#1,d0
-
-	.writeX:
-		move.w	d0,(a2)+	; write to buffer
-		dbf	d1,.loop		; process next sprite piece
-
-	.return:
-		rts
-; ===========================================================================
+		buildsprite	1,0			; draw sprite (X-flip, no Y-flip)
+; ---------------------------------------------------------------------------
 
 BuildSpr_FlipY:
-		cmpi.b	#$50,d5		; check sprite limit
-		beq.s	.return
-		move.b	(a1)+,d0	; get y-offset
-		move.b	(a1),d4		; get size
-		ext.w	d0
-		neg.w	d0		; negate y-offset
-		lsl.b	#3,d4	; calculate flip offset
-		andi.w	#$18,d4
-		addq.w	#8,d4
-		sub.w	d4,d0
-		add.w	d2,d0	; add y-position
-		move.w	d0,(a2)+	; write to buffer
-		move.b	(a1)+,(a2)+	; size
-		addq.b	#1,d5
-		move.b	d5,(a2)+	; link
-		move.b	(a1)+,d0	; art tile
-		lsl.w	#8,d0
-		move.b	(a1)+,d0
-		add.w	a3,d0
-		eori.w	#$1000,d0	; toggle flip-y in VDP
-		move.w	d0,(a2)+
-		move.b	(a1)+,d0	; x-position
-		ext.w	d0
-		add.w	d3,d0
-		andi.w	#$1FF,d0
-		bne.s	.writeX
-		addq.w	#1,d0
-
-	.writeX:
-		move.w	d0,(a2)+	; write to buffer
-		dbf	d1,BuildSpr_FlipY	; process next sprite piece
-
-	.return:
-		rts
-; ===========================================================================
+		buildsprite	0,1			; draw sprite (no X-flip, Y-flip)
+; ---------------------------------------------------------------------------
 
 BuildSpr_FlipXY:
-		cmpi.b	#$50,d5		; check sprite limit
-		beq.s	.return
-		move.b	(a1)+,d0	; calculated flipped y
-		move.b	(a1),d4
-		ext.w	d0
-		neg.w	d0
-		lsl.b	#3,d4
-		andi.w	#$18,d4
-		addq.w	#8,d4
-		sub.w	d4,d0
-		add.w	d2,d0
-		move.w	d0,(a2)+	; write to buffer
-		move.b	(a1)+,d4	; size
-		move.b	d4,(a2)+	; link
-		addq.b	#1,d5
-		move.b	d5,(a2)+	; art tile
-		move.b	(a1)+,d0
-		lsl.w	#8,d0
-		move.b	(a1)+,d0
-		add.w	a3,d0
-		eori.w	#$1800,d0	; toggle flip-x/y in VDP
-		move.w	d0,(a2)+
-		move.b	(a1)+,d0	; calculate flipped x
-		ext.w	d0
-		neg.w	d0
-		add.b	d4,d4
-		andi.w	#$18,d4
-		addq.w	#8,d4
-		sub.w	d4,d0
-		add.w	d3,d0
-		andi.w	#$1FF,d0
-		bne.s	.writeX
-		addq.w	#1,d0
-
-	.writeX:
-		move.w	d0,(a2)+	; write to buffer
-		dbf	d1,BuildSpr_FlipXY	; process next sprite piece
-
-	.return:
-		rts
+		buildsprite	1,1			; draw sprite (both X-flip and Y-flip)
+; End of function BuildSpr_Draw

--- a/_inc/BuildSprites.asm
+++ b/_inc/BuildSprites.asm
@@ -24,7 +24,7 @@ BuildSprites:
 		lea	(v_spritetablebuffer).w,a2
 		moveq	#0,d5
 		lea	(v_spritequeue).w,a4
-		moveq	#spritequeue_layernum-1,d7
+		moveq	#spritelayer_num-1,d7
 
 .priorityLoop:
 		tst.w	(a4)				; are there objects left to draw in current priority layer?
@@ -121,7 +121,7 @@ BuildSprites:
 		bne.w	.objectLoop			; if entries remain, loop
 
 .nextPriority:
-		lea	spritequeue_layersize(a4),a4	; advance to next layer (each layer is $80 bytes)
+		lea	spritelayer_size(a4),a4		; advance to next layer (each layer is $80 bytes)
 		dbf	d7,.priorityLoop
 		
 		move.b	d5,(v_spritecount).w		; write number of rendered sprites to debug var

--- a/_inc/BuildSprites.asm
+++ b/_inc/BuildSprites.asm
@@ -1,161 +1,142 @@
 ; ===========================================================================
-; ---------------------------------------------------------------------------
-; Subroutine to convert mappings (etc) to proper Mega Drive sprites
-; ---------------------------------------------------------------------------
+; BuildSprites camera pointers to be used depending on bits 2-3 in obRender.
 
-BldSpr_ScrPos:	dc.l 0					; blank
-		dc.l v_screenposx&$FFFFFF		; main screen X-position
-		dc.l v_bgscreenposx&$FFFFFF		; background X-position 1 (unused)
-		dc.l v_bg3screenposx&$FFFFFF		; background X-position 2 (unused)
+; Here they point to the camera X-position, and it's expected that 4 bytes
+; after it the camera Y-position is located (e.g. v_screenposx/v_screenposy).
+; Note that the last two background camera pointers go completely unused
+; in the entire game, though they may have once been used for the
+; foreground palm trees in the Tokyo Toy Show demo.
 
+; BldSpr_ScrPos:
+BuildSpr_Cameras:
+		dc.l 0					; null (fallback for on-screen coordinates)
+		dc.l v_screenposx&$FFFFFF		; foreground camera
+		dc.l v_bgscreenposx&$FFFFFF		; background camera 1 (unused)
+		dc.l v_bg3screenposx&$FFFFFF		; background camera 2 (unused)
+; ===========================================================================
+
+; ---------------------------------------------------------------------------
+; Subroutine to convert mappings (etc) into proper Mega Drive sprites
+; and queue them into a linked sprite buffer table (transferred in VBlank).
 ; ---------------------------------------------------------------------------
 
 BuildSprites:
-		lea	(v_spritetablebuffer).w,a2	; set address for sprite table
-		moveq	#0,d5				; reset sprite counter to 0
-		lea	(v_spritequeue).w,a4		; load sprite queue priority layers
-		moveq	#spritequeue_layers-1,d7	; iterate through all eight layers
+		lea	(v_spritetablebuffer).w,a2
+		moveq	#0,d5
+		lea	(v_spritequeue).w,a4
+		moveq	#spritequeue_layernum-1,d7
 
 .priorityLoop:
 		tst.w	(a4)				; are there objects left to draw in current priority layer?
 		beq.w	.nextPriority			; if not, go to next priority layer
 
-		moveq	#spritequeue_counter,d6		; initialize offset pointer to first object after entry counter (2 bytes)
+		moveq	#2,d6				; initialize offset pointer to first object after entry counter (2 bytes)
 	.objectLoop:
-		movea.w	(a4,d6.w),a0			; load object ID
-		tst.b	(a0)				; has an object been queued for display but deleted?
+		movea.w	(a4,d6.w),a0			; load object's address in RAM
+		tst.b	obID(a0)			; has an object been queued for display but deleted?
 		beq.w	.skipObject			; if yes, skip (this appears to be an effort to fix display-and-delete bugs)
 		bclr	#7,obRender(a0)			; set object as not visible
 
 	; --- Coordinate system ---
-		move.b	obRender(a0),d0			; get object's render flags
-		move.b	d0,d4				; backup for later
-		andi.w	#%1100,d0			; get drawing coordinate system (bit 2-3)
-		beq.s	.screenCoords			; branch if 0 (screen-positioning coordinate system)
-		movea.l	BldSpr_ScrPos(pc,d0.w),a1	; get relative screen position (in practice, only v_screenposx is ever used)
+		move.b	obRender(a0),d0
+		move.b	d0,d4
+		andi.w	#%1100,d0			; get drawing coordinate system in render flags (bit 2-3)
+		beq.s	.screenCoords			; branch if 0 (on-screen positioning coordinate system)
+		movea.l	BuildSpr_Cameras(pc,d0.w),a1	; load camera pointers for coordinate system (in practice, only foreground camera is ever used)
 
 	; --- Screen bounds check for X-position ---
-		moveq	#0,d0				; clear d0
-		move.b	obActWid(a0),d0			; get object display width
-		move.w	obX(a0),d3			; get object's X-position
-		sub.w	(a1),d3				; subtract relative screen X-position
-		move.w	d3,d1				; remember difference result
-		add.w	d0,d1				; add object display width
+		moveq	#0,d0
+		move.b	obActWid(a0),d0			; get display width
+		move.w	obX(a0),d3
+		sub.w	(a1),d3				; subtract camera X-position
+		move.w	d3,d1
+		add.w	d0,d1				; d1 = obX - cameraX + obActWid
 		bmi.w	.skipObject			; if underflowed, left edge is out of bounds
-		move.w	d3,d1				; restore difference result
-		sub.w	d0,d1				; subtract object display width
-		cmpi.w	#320,d1				; is result greater than the screen width? (320px)
+		move.w	d3,d1
+		sub.w	d0,d1				; d1 = obX - cameraX - obActWid
+		cmpi.w	#320,d1				; is result greater than screen width?
 		bge.s	.skipObject			; if yes, right edge is out of bounds
-		addi.w	#sprites_basepos,d3		; VDP sprites start at 128px
+		addi.w	#$80,d3				; add VDP sprite start
 
 	; --- Screen bounds check for Y-position ---
 		btst	#4,d4				; is custom height flag set?
 		beq.s	.assumeHeight			; if not, assume height instead
 
-		moveq	#0,d0				; clear d0
-		move.b	obHeight(a0),d0			; get custom object height
-		move.w	obY(a0),d2			; get object's Y-position
-		sub.w	4(a1),d2			; subtract relative screen Y-position
-		move.w	d2,d1				; remember result
-		add.w	d0,d1				; add object display height
-		bmi.s	.skipObject			; if underflowed, top edge is out of bounds
-		move.w	d2,d1				; restore difference result
-		sub.w	d0,d1				; subtract object display height
-		cmpi.w	#224,d1				; is result greater than the screen height? (224px)
+		moveq	#0,d0
+		move.b	obHeight(a0),d0			; use custom height
+		move.w	obY(a0),d2
+		sub.w	4(a1),d2			; subtract camera Y-position
+		move.w	d2,d1
+		add.w	d0,d1				; d1 = obY - cameraY + obHeight
+		bmi.s	.skipObject			; if negative, top edge is out of bounds
+		move.w	d2,d1
+		sub.w	d0,d1				; d1 = obY - cameraY - obHeight
+		cmpi.w	#224,d1				; is result greater than screen height?
 		bge.s	.skipObject			; if yes, bottom edge is out of bounds
-		addi.w	#sprites_basepos,d2		; VDP sprites start at 128px
-		bra.s	.drawObject			; skip over
+		addi.w	#$80,d2				; add VDP sprite start
+		bra.s	.drawObject
 ; ---------------------------------------------------------------------------
 
 	.screenCoords:
 		move.w	obScreenY(a0),d2		; special variable for screen Y
-		move.w	obX(a0),d3			; get object's X-position
-		bra.s	.drawObject			; skip over
+		move.w	obX(a0),d3
+		bra.s	.drawObject
 ; ---------------------------------------------------------------------------
 
 	.assumeHeight:
-		.ah:	equ 32				; assumed height is 32px ($20)
-		move.w	obY(a0),d2			; get object's Y-position
-		sub.w	4(a1),d2			; subtract relative screen Y-position (v_screenposy)
-		addi.w	#sprites_basepos,d2		; VDP sprites start at 128px
-		cmpi.w	#sprites_basepos-.ah,d2		; is top Y-position more than 32px out of bounds?
-		blo.s	.skipObject			; if yes, assumed height top edge is out of bounds
-		cmpi.w	#sprites_basepos+224+.ah,d2	; is bottom Y-position more than 32px out of bounds?
-		bhs.s	.skipObject			; if yes, assumed height bottom edge is out of bounds
+		.ah:	equ 32				; assumed height = 32px ($20)
+		move.w	obY(a0),d2
+		sub.w	4(a1),d2			; subtract camera Y-position
+		addi.w	#$80,d2
+		cmpi.w	#$80-.ah,d2			; is top Y-position with assumed height out of bounds?
+		blo.s	.skipObject			; if yes, branch
+		cmpi.w	#$80+224+.ah,d2			; is bottom Y-position with assumed height out of bounds?
+		bhs.s	.skipObject			; if yes, branch
 
 	; --- Load sprite mappings ---
 	.drawObject:
-		movea.l	obMap(a0),a1			; get absolute object mappings pointer
+		movea.l	obMap(a0),a1
 
 		moveq	#1-1,d1				; write only one sprite for raw-mappings
 		btst	#5,d4				; is "raw-mappings" flag on?
 		bne.s	.drawFrame			; if yes, branch (assume mappings point to a single sprite piece)
 
-		move.b	obFrame(a0),d1			; get current object frame ID
-		add.b	d1,d1				; double it for word-based indexing
+		move.b	obFrame(a0),d1
+		add.b	d1,d1
 		adda.w	(a1,d1.w),a1			; get mappings frame address
 		move.b	(a1)+,d1			; get number of sprite pieces in frame
 		subq.b	#1,d1				; subtract 1 for dbf
-		bmi.s	.setVisible			; if result underflowed, this is was blank frame mapping, branch
+		bmi.s	.setVisible			; skip rendering if mapping was blank
 
 	; --- Do the actual sprite mapping rendering ---
 	.drawFrame:
-		bsr.w	BuildSpr_Draw			; write data from sprite pieces to buffer, potentially flipped
+		bsr.w	BuildSpr_Draw
 
 	.setVisible:
 		bset	#7,obRender(a0)			; set object as visible
 
 	.skipObject:
-		addq.w	#2,d6				; advance to next entry in sprite priority layer
-		subq.w	#2,(a4)				; decrement number of objects left in sprite priority layer
-		bne.w	.objectLoop			; if more objects are left to render, loop
+		addq.w	#2,d6				; advance to next entry in layer
+		subq.w	#2,(a4)				; decrement number of objects left
+		bne.w	.objectLoop			; if entries remain, loop
 
 .nextPriority:
-		lea	spritequeue_layersize(a4),a4	; advance to next sprite priority layer (each layer is $80 bytes)
-		dbf	d7,.priorityLoop		; loop for all 8 layers
-
-		move.b	d5,(v_spritecount).w		; write total number of rendered sprites to debug value
-
-		cmpi.b	#sprites_max,d5			; check sprite limit (Mega Drive can only handle 80 at a time)
-	if FixBugs
-		bhs.s	.spriteLimit			; if all sprite slots are taken up (or more), abort process
-	else
-		; See notes below.
-		beq.s	.spriteLimit			; if all sprite slots are taken up (exactly), abort process
-	endif
-
+		lea	spritequeue_layersize(a4),a4	; advance to next layer (each layer is $80 bytes)
+		dbf	d7,.priorityLoop
+		
+		move.b	d5,(v_spritecount).w		; write number of rendered sprites to debug var
+		cmpi.b	#sprites_max,d5			; check if sprite limit was exhausted
+		beq.s	.spriteLimit			; if yes, branch
 		move.l	#0,(a2)				; unlink last sprite
-		rts					; return
+		rts
 ; ---------------------------------------------------------------------------
 
 	.spriteLimit:
 		move.b	#0,-5(a2)			; unlink penultimate sprite
-		rts					; return
+		rts
 ; End of function BuildSprites
 
 
-; ===========================================================================
-; ---------------------------------------------------------------------------
-; Each sprite piece is exactly 5 bytes long. Broken down into bits,
-; they have the format "TTTTTTTT ----WWHH PCCYXAAA AAAAAAAA LLLLLLLL":
-; 
-; Value | Size    | Description
-; -----------------------------
-; T     | Byte    | Top relative coordinate of where the piece appears
-; -     | 4 bits  | Always null/unused
-; W     | 2 bits  | Width of the piece, in tiles minus one:
-;       |         |   0 => 8 pixels wide
-;       |         |   1 => 16 pixels wide
-;       |         |   2 => 24 pixels wide
-;       |         |   3 => 32 pixels wide
-; H     | 2 bits  | Height of the piece, in the same format as the width WW
-; P     | 1 bit   | Priority flag. If set, the piece will appear above everything else
-; C     | 2 bits  | Palette line number
-; X     | 1 bit   | X-flip-flag. If set, the piece will be flipped horizontally
-; Y     | 1 bit   | Y-flip-flag. If set, the piece will be flipped vertically
-; A     | 11 bits | Relative art tile index, spread across two bytes
-; L     | Byte    | Left relative coordinate of where the piece appears
-; ---------------------------------------------------------------------------
 ; ===========================================================================
 ; ---------------------------------------------------------------------------
 ; Macro for BuildSpr_Draw, to visualize the differences between the flips.
@@ -172,81 +153,77 @@ BuildSprites:
 ;	a3 = art tile / VRAM setting (obGfx)
 ;
 ; 	uses d0.w, d4.w
+;
+; Each sprite piece is exactly 5 bytes. See here for a breakdown:
+; https://info.sonicretro.org/SCHG:Sonic_the_Hedgehog_(16-bit)/Object_Editing#Mappings_editing
 ; ---------------------------------------------------------------------------
 
 buildsprite:	macro xflip,yflip
 
 .loopSpritePieces:
 	; --- Sprite limit check ---
-		cmpi.b	#sprites_max,d5			; check sprite limit (Mega Drive can only handle 80 at a time)
-	if FixBugs
-		bhs.s	.return				; if all sprite slots are taken up (or more), abort process
-	else
-		; This checks if the sprite buffer contains EXACTLY 80 entries, but
-		; it will still continue should it somehow end up with MORE, which
-		; is very dangerous. The above fix introduces no additional overhead.
-		beq.s	.return				; if all sprite slots are taken up (exactly), abort process
-	endif
+		cmpi.b	#sprites_max,d5			; check sprite limit
+		beq.s	.return				; if all sprite slots are taken up, abort process
 
 	; --- Y-position ---
-		move.b	(a1)+,d0			; get relative y-offset
+		move.b	(a1)+,d0			; get relative Y-offset
 		if yflip
-			move.b	(a1),d4			; get width and height dimensions of sprite piece (WWHH)
-			ext.w	d0			; extend y-offset to word
-			neg.w	d0			; negate y-offset
-			lsl.b	#3,d4			; multiply height dimension (HH) to multiple of 8px
-			andi.w	#%11000,d4		; mask out non-height bits
-			addq.w	#8,d4			; account of HH=0 being treated as a single 8px tile
-			sub.w	d4,d0			; subtract result from negated Y position to get flipped Y position
+			move.b	(a1),d4			; get dimensions of sprite piece
+			ext.w	d0
+			neg.w	d0
+			lsl.b	#3,d4
+			andi.w	#%11000,d4
+			addq.w	#8,d4
+			sub.w	d4,d0			; d0 = flipped Y-position
 		else
-			ext.w	d0			; extend y-offset to word
+			ext.w	d0
 		endif
 		add.w	d2,d0				; add base Y-position
-		move.w	d0,(a2)+			; write to buffer
+		move.w	d0,(a2)+			; write Y-position to buffer
 
 	; --- Sprite width/height ---
 		if xflip
-			move.b	(a1)+,d4		; get width and height dimensions of sprite piece (backup for later)
-			move.b	d4,(a2)+		; write dimension
+			move.b	(a1)+,d4		; get dimensions of sprite piece (WWHH) (backup for later)
+			move.b	d4,(a2)+		; write sprite width to buffer
 		else
-			move.b	(a1)+,(a2)+		; write width and height dimensions of sprite piece
+			move.b	(a1)+,(a2)+		; write sprite width to buffer
 		endif
 
 	; --- Sprite link ---
 		addq.b	#1,d5				; increase total sprites counter
-		move.b	d5,(a2)+			; set sprites counter as sprite link
+		move.b	d5,(a2)+			; write sprite link to buffer
 
 	; --- VRAM settings / art tile / flipping ---
-		move.b	(a1)+,d0			; get first half of VRAM settings (flag and three bits of tile offset)
-		lsl.w	#8,d0				; shift it to upper byte
-		move.b	(a1)+,d0			; get second half of VRAM settings (remaining eight bits of tile offset)
+		move.b	(a1)+,d0			; get first half of VRAM settings
+		lsl.w	#8,d0
+		move.b	(a1)+,d0			; get second half of VRAM settings
 		add.w	a3,d0				; add base art tile offset of object
 		if xflip|yflip
 			eori.w	#xflip<<11|yflip<<12,d0	; toggle X-flip ($800) and/or Y-flip ($1000) in VDP
 		endif
-		move.w	d0,(a2)+			; write sprite art tile and flags to buffer
+		move.w	d0,(a2)+			; write VRAM settings to buffer
 
 	; --- X-position ---
-		move.b	(a1)+,d0			; get relative x-offset
-		ext.w	d0				; extend x-offset to word
+		move.b	(a1)+,d0			; get relative X-offset
+		ext.w	d0
 		if xflip
-			neg.w	d0			; negate x-offset
-			add.b	d4,d4			; multiply width dimension (WW) to multiple of 8px
-			andi.w	#%11000,d4		; mask out non-width bits
-			addq.w	#8,d4			; account of WW=0 being treated as a single 8px tile
-			sub.w	d4,d0			; subtract result from negated X-position to get flipped X-position
+			neg.w	d0
+			add.b	d4,d4
+			andi.w	#%11000,d4
+			addq.w	#8,d4
+			sub.w	d4,d0			; d0 = flipped X-position
 		endif
 		add.w	d3,d0				; add X-position
 		andi.w	#$1FF,d0			; keep within 512px (screen wrap)
-		bne.s	.x				; is X-position zero? if not, branch
-		addq.w	#1,d0				; force non-zero X-position to avoid unwanted sprite masking
-	.x:	move.w	d0,(a2)+			; write to buffer
+		bne.s	.x				; if non-zero, branch
+		addq.w	#1,d0				; force zero X-position to non-zero (avoid unwanted sprite masking)
+	.x:	move.w	d0,(a2)+			; write X-position to buffer
 
 	; --- Loop for all pieces in mapping ---
-		dbf	d1,.loopSpritePieces		; process next sprite piece
+		dbf	d1,.loopSpritePieces
 
 	.return:
-		rts					; sprite rendering for this object done
+		rts
 
 	endm
 
@@ -257,7 +234,7 @@ buildsprite:	macro xflip,yflip
 ; ---------------------------------------------------------------------------
 
 BuildSpr_Draw:
-		movea.w	obGfx(a0),a3			; get art tile / VRAM settings for object
+		movea.w	obGfx(a0),a3
 
 		btst	#0,d4				; is X-flip flag set?
 		bne.s	BuildSpr_FlipX			; if yes, branch
@@ -265,20 +242,20 @@ BuildSpr_Draw:
 		bne.w	BuildSpr_FlipY			; if yes, branch
 
 BuildSpr_Normal:
-		buildsprite	0,0			; draw sprite (no X-flip or Y-flip)
+		buildsprite	0,0
 ; ---------------------------------------------------------------------------
 
 BuildSpr_FlipX:
-		btst	#1,d4				; is object Y-flipped as well?
+		btst	#1,d4				; is Y-flip flag set as well?
 		bne.w	BuildSpr_FlipXY			; if yes, branch
 
-		buildsprite	1,0			; draw sprite (X-flip, no Y-flip)
+		buildsprite	1,0
 ; ---------------------------------------------------------------------------
 
 BuildSpr_FlipY:
-		buildsprite	0,1			; draw sprite (no X-flip, Y-flip)
+		buildsprite	0,1
 ; ---------------------------------------------------------------------------
 
 BuildSpr_FlipXY:
-		buildsprite	1,1			; draw sprite (both X-flip and Y-flip)
+		buildsprite	1,1
 ; End of function BuildSpr_Draw

--- a/_incObj/sub DisplaySprite.asm
+++ b/_incObj/sub DisplaySprite.asm
@@ -6,8 +6,8 @@ DisplaySprite:
 		lea	(v_spritequeue).w,a1		; load sprite priority layer buffer
 		move.w	obPriority(a0),d0		; get sprite priority as word (prio 0-7 in upper byte)
 		lsr.w	#1,d0				; divide by 2 because each layer is $80 bytes
-		andi.w	#spritequeue_layersize*7,d0	; mask to possible offset starts per layer ($380)
-		adda.w	d0,a1				; jump to position in queue
+		andi.w	#spritequeue_layersize*(spritequeue_layernum-1),d0 ; mask to possible offset starts per layer ($80*7=$380)
+		adda.w	d0,a1				; jump to start of appropriate priority layer
 		cmpi.w	#spritequeue_layersize-2,(a1)	; is this sprite priority layer full? ($7E bytes)
 		bhs.s	DSpr_Full			; if yes, branch
 		addq.w	#2,(a1)				; increment sprite counter
@@ -28,8 +28,8 @@ DisplaySprite2:
 		lea	(v_spritequeue).w,a2		; load sprite priority layer buffer
 		move.w	obPriority(a1),d0		; get sprite priority as word (prio 0-7 in upper byte)
 		lsr.w	#1,d0				; divide by 2 because each layer is $80 bytes
-		andi.w	#spritequeue_layersize*7,d0	; mask to possible offset starts per layer ($380)
-		adda.w	d0,a2				; jump to position in queue
+		andi.w	#spritequeue_layersize*(spritequeue_layernum-1),d0 ; mask to possible offset starts per layer ($80*7=$380)
+		adda.w	d0,a2				; jump to start of appropriate priority layer
 		cmpi.w	#spritequeue_layersize-2,(a2)	; is this sprite priority layer full? ($7E bytes)
 		bhs.s	DSpr2_Full			; if yes, branch
 		addq.w	#2,(a2)				; increment sprite counter

--- a/_incObj/sub DisplaySprite.asm
+++ b/_incObj/sub DisplaySprite.asm
@@ -3,16 +3,16 @@
 ; ---------------------------------------------------------------------------
 
 DisplaySprite:
-		lea	(v_spritequeue).w,a1
-		move.w	obPriority(a0),d0 ; get sprite priority
-		lsr.w	#1,d0
-		andi.w	#$380,d0
-		adda.w	d0,a1		; jump to position in queue
-		cmpi.w	#$7E,(a1)	; is this part of the queue full?
-		bhs.s	DSpr_Full	; if yes, branch
-		addq.w	#2,(a1)		; increment sprite count
-		adda.w	(a1),a1		; jump to empty position
-		move.w	a0,(a1)		; insert RAM address for object
+		lea	(v_spritequeue).w,a1		; load sprite priority layer buffer
+		move.w	obPriority(a0),d0		; get sprite priority as word (prio 0-7 in upper byte)
+		lsr.w	#1,d0				; divide by 2 because each layer is $80 bytes
+		andi.w	#spritequeue_layersize*7,d0	; mask to possible offset starts per layer ($380)
+		adda.w	d0,a1				; jump to position in queue
+		cmpi.w	#spritequeue_entries,(a1)	; is this sprite priority layer full? ($7E bytes)
+		bhs.s	DSpr_Full			; if yes, branch
+		addq.w	#2,(a1)				; increment sprite counter
+		adda.w	(a1),a1				; jump to empty position
+		move.w	a0,(a1)				; insert RAM address for object
 
 DSpr_Full:
 		rts
@@ -25,16 +25,16 @@ DSpr_Full:
 
 ; DisplaySprite1: <-- old misnomer
 DisplaySprite2:
-		lea	(v_spritequeue).w,a2
-		move.w	obPriority(a1),d0
-		lsr.w	#1,d0
-		andi.w	#$380,d0
-		adda.w	d0,a2
-		cmpi.w	#$7E,(a2)
-		bhs.s	DSpr2_Full
-		addq.w	#2,(a2)
-		adda.w	(a2),a2
-		move.w	a1,(a2)
+		lea	(v_spritequeue).w,a2		; load sprite priority layer buffer
+		move.w	obPriority(a1),d0		; get sprite priority as word (prio 0-7 in upper byte)
+		lsr.w	#1,d0				; divide by 2 because each layer is $80 bytes
+		andi.w	#spritequeue_layersize*7,d0	; mask to possible offset starts per layer ($380)
+		adda.w	d0,a2				; jump to position in queue
+		cmpi.w	#spritequeue_entries,(a2)	; is this sprite priority layer full? ($7E bytes)
+		bhs.s	DSpr2_Full			; if yes, branch
+		addq.w	#2,(a2)				; increment sprite counter
+		adda.w	(a2),a2				; jump to empty position
+		move.w	a1,(a2)				; insert RAM address for object
 
 DSpr2_Full:
 		rts

--- a/_incObj/sub DisplaySprite.asm
+++ b/_incObj/sub DisplaySprite.asm
@@ -4,11 +4,11 @@
 
 DisplaySprite:
 		lea	(v_spritequeue).w,a1		; load sprite priority layer buffer
-		move.w	obPriority(a0),d0		; get sprite priority as word (prio 0-7 in upper byte)
-		lsr.w	#1,d0				; divide by 2 because each layer is $80 bytes
-		andi.w	#spritequeue_layersize*(spritequeue_layernum-1),d0 ; mask to possible offset starts per layer ($80*7=$380)
+		move.w	obPriority(a0),d0		; d0 = priority level * $100 (lower byte ignored)
+		lsr.w	#8-spritelayer_size_bits,d0	; d0 = priority level * spritequeue_layersize (lower bits ignored)
+		andi.w	#spritelayer_size*(spritelayer_num-1),d0 ; mask to possible offset starts per layer ($80*7=$380)
 		adda.w	d0,a1				; jump to start of appropriate priority layer
-		cmpi.w	#spritequeue_layersize-2,(a1)	; is this sprite priority layer full? ($7E bytes)
+		cmpi.w	#spritelayer_size-2,(a1)	; is this sprite priority layer full? ($7E bytes)
 		bhs.s	DSpr_Full			; if yes, branch
 		addq.w	#2,(a1)				; increment sprite counter
 		adda.w	(a1),a1				; jump to empty position
@@ -26,11 +26,11 @@ DSpr_Full:
 ; DisplaySprite1: <-- old misnomer
 DisplaySprite2:
 		lea	(v_spritequeue).w,a2		; load sprite priority layer buffer
-		move.w	obPriority(a1),d0		; get sprite priority as word (prio 0-7 in upper byte)
-		lsr.w	#1,d0				; divide by 2 because each layer is $80 bytes
-		andi.w	#spritequeue_layersize*(spritequeue_layernum-1),d0 ; mask to possible offset starts per layer ($80*7=$380)
+		move.w	obPriority(a1),d0		; d0 = priority level * $100 (lower byte ignored)
+		lsr.w	#8-spritelayer_size_bits,d0	; d0 = priority level * spritequeue_layersize (lower bits ignored)
+		andi.w	#spritelayer_size*(spritelayer_num-1),d0 ; mask to possible offset starts per layer ($80*7=$380)
 		adda.w	d0,a2				; jump to start of appropriate priority layer
-		cmpi.w	#spritequeue_layersize-2,(a2)	; is this sprite priority layer full? ($7E bytes)
+		cmpi.w	#spritelayer_size-2,(a2)	; is this sprite priority layer full? ($7E bytes)
 		bhs.s	DSpr2_Full			; if yes, branch
 		addq.w	#2,(a2)				; increment sprite counter
 		adda.w	(a2),a2				; jump to empty position

--- a/_incObj/sub DisplaySprite.asm
+++ b/_incObj/sub DisplaySprite.asm
@@ -8,7 +8,7 @@ DisplaySprite:
 		lsr.w	#1,d0				; divide by 2 because each layer is $80 bytes
 		andi.w	#spritequeue_layersize*7,d0	; mask to possible offset starts per layer ($380)
 		adda.w	d0,a1				; jump to position in queue
-		cmpi.w	#spritequeue_entries,(a1)	; is this sprite priority layer full? ($7E bytes)
+		cmpi.w	#spritequeue_layersize-2,(a1)	; is this sprite priority layer full? ($7E bytes)
 		bhs.s	DSpr_Full			; if yes, branch
 		addq.w	#2,(a1)				; increment sprite counter
 		adda.w	(a1),a1				; jump to empty position
@@ -30,7 +30,7 @@ DisplaySprite2:
 		lsr.w	#1,d0				; divide by 2 because each layer is $80 bytes
 		andi.w	#spritequeue_layersize*7,d0	; mask to possible offset starts per layer ($380)
 		adda.w	d0,a2				; jump to position in queue
-		cmpi.w	#spritequeue_entries,(a2)	; is this sprite priority layer full? ($7E bytes)
+		cmpi.w	#spritequeue_layersize-2,(a2)	; is this sprite priority layer full? ($7E bytes)
 		bhs.s	DSpr2_Full			; if yes, branch
 		addq.w	#2,(a2)				; increment sprite counter
 		adda.w	(a2),a2				; jump to empty position


### PR DESCRIPTION
A big chunk of duplicated code for the flipping was compressed into a macro for better readability. Also introduced sprite-related constants and updated DisplaySprite source.

Special Stages handle sprite rendering separately, will be done in a future commit.