### PR TITLE
Deferred mappings/animations macros

### DIFF
--- a/_inc/Special Stage Mappings & VRAM Pointers.asm
+++ b/_inc/Special Stage Mappings & VRAM Pointers.asm
@@ -1,3 +1,4 @@
+; ===========================================================================
 ; ---------------------------------------------------------------------------
 ; Special stage mappings and VRAM pointers (loaded into v_ss_spritesettings)
 ; ---------------------------------------------------------------------------
@@ -103,3 +104,17 @@ id_SS_Glass_Ani3:	specialStageData	0, Map_SS_Glass,  Tile_Pal2, ArtTile_SS_Glass
 id_SS_Glass_Ani4:	specialStageData	0, Map_SS_Glass,  Tile_Pal3, ArtTile_SS_Glass		; $4E - ''
 
 SS_MapIndex_End:
+
+; ===========================================================================
+
+Map_SS_Shared:	include	"_maps/SS Shared Block.asm"
+Map_SS_Glass:	include	"_maps/SS Glass Block.asm"
+Map_SS_Up:	include	"_maps/SS UP Block.asm"
+Map_SS_Down:	include	"_maps/SS DOWN Block.asm"
+Map_SS_Chaos:	include	"_maps/SS Chaos Emeralds.asm"
+
+; Mappings for Map_SSWalls are located near the end in ROM.
+includes_sswalls_maps: macro {GLOBALSYMBOLS}
+		include	"_maps/SS Walls.asm"
+	endm
+

--- a/_incObj/08 LZ Water Splash.asm
+++ b/_incObj/08 LZ Water Splash.asm
@@ -35,3 +35,14 @@ Spla_Display:	; Routine 2
 
 Spla_Delete:	; Routine 4
 		jmp	(DeleteObject).l			; delete when animation is complete
+
+; ===========================================================================
+
+; Mappings and animations for the water splash are located after the assets for shield/stars and unused SS entry in ROM.
+includes_watersplash: macro {GLOBALSYMBOLS}
+		include	"_anim/Water Splash.asm"
+Map_Splash:	include	"_maps/Water Splash.asm"
+	endm
+
+
+

--- a/_incObj/24 Unused - Small Explosion.asm
+++ b/_incObj/24 Unused - Small Explosion.asm
@@ -42,3 +42,10 @@ UnkExpl_Animate:	; Routine 2
 
 .display:
 		bra.w	DisplaySprite
+
+; ===========================================================================
+
+; Mappings for the unused explosions are located after the Ball Hog badnik and other explosions in ROM.
+includes_unkexplosion: macro {GLOBALSYMBOLS}
+Map_UnkExplode:	include	"_maps/Unused Explosion.asm"
+	endm

--- a/_incObj/25, 37 Rings.asm
+++ b/_incObj/25, 37 Rings.asm
@@ -373,3 +373,18 @@ RLoss_Sparkle:	; Routine 6
 RLoss_Delete:	; Routine 8
 		bra.w	DeleteObject				; delete this ring
 
+; ===========================================================================
+
+; Rings animation and mapping data is located after giant rings in ROM,
+; likely because they were created together.
+includes_rings: macro {GLOBALSYMBOLS}
+		include	"_anim/Rings.asm"
+Map_Ring:
+	if Revision=0
+		include	"_maps/Rings (REV00).asm"
+	else
+		; REV01 added an extra blank frame, possibly to mitigate
+		; rings occasionally popping up in the sign post sparkles
+		include	"_maps/Rings (REV01).asm"
+	endif
+	endm

--- a/_incObj/27, 3F Explosions.asm
+++ b/_incObj/27, 3F Explosions.asm
@@ -80,3 +80,11 @@ Expl_Main:	; Routine 0
 		move.b	#0,obFrame(a0)			; start at frame 0
 		move.w	#sfx_Bomb,d0			; set explosion sound
 		jmp	(QueueSound2).l			; play it
+
+; ===========================================================================
+
+; Mappings for the explosions are located after the Ball Hog badnik and unused explosion in ROM.
+includes_explosion: macro {GLOBALSYMBOLS}
+		; Contains Map_ExplodeItem and Map_ExplodeBomb (cross-referencing!)
+		include	"_maps/Explosions.asm"
+	endm

--- a/_incObj/31 MZ Chained Stompers.asm
+++ b/_incObj/31 MZ Chained Stompers.asm
@@ -309,3 +309,10 @@ loc_B98C:
 
 loc_B996:
 		bra.w	CStom_Restart
+
+; ===========================================================================
+
+; Mappings for the chained stomper come after the unused sideways stomper in ROM.
+includes_chainedstomper: macro {GLOBALSYMBOLS}
+Map_CStom:	include	"_maps/Chained Stompers.asm"
+	endm

--- a/_incObj/38 Shield and Invincibility.asm
+++ b/_incObj/38 Shield and Invincibility.asm
@@ -109,3 +109,12 @@ Shi_Stars:	; Routine 4
 
 Shi_Start_Delete:	
 		jmp	(DeleteObject).l			; delete invincibility stars object
+
+; ===========================================================================
+
+; Mappings and animations for the shield/stars are located unused SS entry and LZ water splash in ROM.
+includes_shieldandstars: macro {GLOBALSYMBOLS}
+		include	"_anim/Shield and Invincibility.asm"
+Map_Shield:	include	"_maps/Shield and Invincibility.asm"
+	endm
+

--- a/_incObj/3B GHZ Purple Rock.asm
+++ b/_incObj/3B GHZ Purple Rock.asm
@@ -1,3 +1,4 @@
+; ===========================================================================
 ; ---------------------------------------------------------------------------
 ; Object 3B - purple rock (GHZ)
 ; ---------------------------------------------------------------------------
@@ -17,13 +18,14 @@ Rock_Main:	; Routine 0
 		move.l	#Map_PRock,obMap(a0)
 		move.w	#ArtTile_GHZ_Purple_Rock|Tile_Pal4,obGfx(a0)
 		move.b	#4,obRender(a0)
-	if FixBugs=0
-		; This should be 48 pixels, currently it gets culled too soon.
-		move.b	#38/2,obActWid(a0)
-	else
+	if FixBugs
 		move.b	#48/2,obActWid(a0)
+	else
+		; This should be 48 pixels, otherwise it gets culled too soon.
+		move.b	#38/2,obActWid(a0)
 	endif
 		move.b	#4,obPriority(a0)
+; ---------------------------------------------------------------------------
 
 Rock_Solid:	; Routine 2
 		move.w	#32/2+sonic_solid_width,d1
@@ -31,6 +33,7 @@ Rock_Solid:	; Routine 2
 		move.w	#32/2,d3
 		move.w	obX(a0),d4
 		bsr.w	SolidObject
+
 	if FixBugs
 		; Objects shouldn't call DisplaySprite and DeleteObject in
 		; the same frame or else cause a null-pointer dereference.
@@ -43,3 +46,10 @@ Rock_Solid:	; Routine 2
 		out_of_range.w	DeleteObject
 		rts
 	endif
+
+; ===========================================================================
+
+; Mappings for the purple rock are located after the invisible waterfall sound trigger object in ROM.
+includes_purplerock: macro {GLOBALSYMBOLS}
+Map_PRock:	include	"_maps/Purple Rock.asm"
+	endm

--- a/_incObj/45 Unused - MZ Sideways Stomper.asm
+++ b/_incObj/45 Unused - MZ Sideways Stomper.asm
@@ -177,3 +177,10 @@ loc_BB3C:
 		add.w	objoff_30(a0),d0
 		move.w	d0,obX(a0)
 		rts
+
+; ===========================================================================
+
+; Mappings for the unused sideways stomper come after the vertical chained stomper in ROM.
+includes_sidewaysstomper: macro {GLOBALSYMBOLS}
+Map_SStom:	include	"_maps/Sideways Stomper.asm"
+	endm

--- a/_incObj/4A Unused - Special Stage Entry.asm
+++ b/_incObj/4A Unused - Special Stage Entry.asm
@@ -55,3 +55,10 @@ Van_LoadSonic:	; Routine 4
 
 .wait:
 		rts
+; ===========================================================================
+
+; Mappings and animations for the unused SS entry are located LZ water splash object and shield/stars assets in ROM.
+includes_ssentryunused: macro {GLOBALSYMBOLS}
+		include	"_anim/Special Stage Entry (Unused).asm"
+Map_Vanish:	include	"_maps/Special Stage Entry (Unused).asm"
+	endm

--- a/_incObj/4B, 7C Giant Ring and Flash.asm
+++ b/_incObj/4B, 7C Giant Ring and Flash.asm
@@ -139,3 +139,11 @@ Flash_Collect:
 
 Flash_Delete:	; Routine 4
 		bra.w	DeleteObject				; delete flash object
+
+; ===========================================================================
+
+; Giant ring mapping data is located after that for normal rings in ROM.
+includes_giantrings: macro {GLOBALSYMBOLS}
+Map_GRing:	include	"_maps/Giant Ring.asm"
+Map_Flash:	include	"_maps/Ring Flash.asm"
+	endm

--- a/_incObj/4C, 4D MZ Lava Geyser and Maker.asm
+++ b/_incObj/4C, 4D MZ Lava Geyser and Maker.asm
@@ -307,3 +307,16 @@ loc_F04C:
 
 Geyser_Delete:	; Routine 6
 		bra.w	DeleteObject
+
+; ===========================================================================
+
+; Mappings and animations for the lava geyser are located after lava wall and invisible lava tag in ROM.
+; They are also interlaced by the the lava wall mappings and animations, requiring two macros.
+includes_lavageyser_anim: macro {GLOBALSYMBOLS}
+		include	"_anim/Lava Geyser.asm"
+	endm
+
+includes_lavageyser_maps: macro {GLOBALSYMBOLS}
+Map_Geyser:	include	"_maps/Lava Geyser.asm"
+	endm
+

--- a/_incObj/4E MZ Wall of Lava.asm
+++ b/_incObj/4E MZ Wall of Lava.asm
@@ -147,3 +147,16 @@ LWall_BackChild: ; Routine 6
 
 LWall_Delete:	; Routine 8
 		bra.w	DeleteObject				; delete lava wall object
+
+; ===========================================================================
+
+; Mappings and animations for the lava wall are located after the invisible lava tag in ROM.
+; They are also interlaced by the the lava geyser mappings and animations, requiring two macros.
+includes_walloflava_anim: macro {GLOBALSYMBOLS}
+		include	"_anim/Wall of Lava.asm"
+	endm
+
+includes_walloflava_maps: macro {GLOBALSYMBOLS}
+Map_LWall:	include	"_maps/Wall of Lava.asm"
+	endm
+

--- a/_incObj/7E, 7F Special Stage Results and Chaos Emeralds.asm
+++ b/_incObj/7E, 7F Special Stage Results and Chaos Emeralds.asm
@@ -291,4 +291,11 @@ SSRC_Flash:	; Routine 2
 	; SSRC_Display:
 	.display:
 		bra.w	DisplaySprite				; display emerald sprite
+
 ; ===========================================================================
+
+; Mappings for the SSR chaos emeralds are located after all title card mappings in ROM.
+includes_ssrchaos: macro {GLOBALSYMBOLS}
+Map_SSRC:	include	"_maps/SS Result Chaos Emeralds.asm"
+	endm
+

--- a/sonic.asm
+++ b/sonic.asm
@@ -4033,9 +4033,11 @@ Demo_EndGHZ2:	include	"demodata/Ending - GHZ2.asm"
 
 
 ; Where possible, includes to _maps and _anim were appended to the _incObj
-; file includes themselves. However, in some cases this wasn't possible,
+; file includes themselves. However, in some cases this couldn't be done,
 ; as the developers weren't very consistent with the placement, especially
-; during the early stages of production. Those includes are still here.
+; during the early stages of production. Those includes needed to be wrapped
+; inside "includes_" macros to keep the definitions inside the object source
+; text files, while still being able to assemble a bit-perfect ROM.
 
 
 ; ===========================================================================
@@ -4052,21 +4054,19 @@ Demo_EndGHZ2:	include	"demodata/Ending - GHZ2.asm"
 
 		include	"_inc/DynamicLevelEvents.asm"
 
-
 ; ===========================================================================
 ; >>> Various level objects
 		include	"_incObj/11 GHZ Bridge.asm"
-		include	"_incObj/15 Swinging Platforms.asm"	; includes "MvSonicOnPtfm" subroutine
+		include	"_incObj/15 Swinging Platforms.asm" ; includes "MvSonicOnPtfm" subroutine
 		include	"_incObj/17 GHZ Spiked Pole Helix.asm"
 		include	"_incObj/18 Platforms.asm"
 		include	"_incObj/19 Unused - Blank.asm" ; this was the rolling GHZ ball in the prototype
 Map_GBall:	include	"_maps/GHZ Ball.asm"
-		include	"_incObj/1A, 53 Collapsing Ledges and Floors.asm"	; includes "SlopeObject_AssumeStoodOn" subroutine
+		include	"_incObj/1A, 53 Collapsing Ledges and Floors.asm" ; includes "SlopeObject_AssumeStoodOn" subroutine
 		include	"_incObj/1C GHZ, SYZ Scenery.asm"
 		include	"_incObj/1D Unused - Switch.asm"
 		include	"_incObj/2A SBZ Small Door.asm"
 		include	"_incObj/sub SolidWall.asm"
-
 
 ; ===========================================================================
 ; >>> Badniks, explosions, and Badnik-related objects
@@ -4074,38 +4074,26 @@ Map_GBall:	include	"_maps/GHZ Ball.asm"
 		include	"_incObj/24 Unused - Small Explosion.asm"
 		include	"_incObj/27, 3F Explosions.asm"
 		includes_ballhog
-Map_UnkExplode:	include	"_maps/Unused Explosion.asm"
-		include	"_maps/Explosions.asm"
+		includes_unkexplosion
+		includes_explosion
 		include	"_incObj/28, 29 Animals and Points.asm"
 		include	"_incObj/1F Badnik - Crabmeat.asm"
 		include	"_incObj/22, 23 Badnik - Buzz Bomber and Missile.asm"
-
 
 ; ===========================================================================
 ; >>> Rings
 		include	"_incObj/25, 37 Rings.asm"
 		include	"_incObj/4B, 7C Giant Ring and Flash.asm"
-		include	"_anim/Rings.asm"
-Map_Ring:   if Revision=0
-		include	"_maps/Rings (REV00).asm"
-	    else
-		; REV01 added an extra blank frame, possibly to mitigate
-		; rings occasionally popping up in the sign post sparkles
-		include	"_maps/Rings (REV01).asm"
-	    endif
-Map_GRing:	include	"_maps/Giant Ring.asm"
-Map_Flash:	include	"_maps/Ring Flash.asm"
-
+		includes_rings
+		includes_giantrings
 
 ; ===========================================================================
 ; >>> Monitors
 		include	"_incObj/26, 2E Monitors and Power-Ups.asm"
 
-
 ; ===========================================================================
 ; >>> Title screen objects (includes AnimateSprite)
 		include	"_incObj/0E, 0F Title Screen - Sonic, Press Start, TM.asm"
-
 
 ; ===========================================================================
 ; >>> More Badniks and level objects
@@ -4113,15 +4101,14 @@ Map_Flash:	include	"_maps/Ring Flash.asm"
 		include	"_incObj/2C Badnik - Jaws.asm"
 		include	"_incObj/2D Badnik - Burrobot.asm"
 		include	"_incObj/2F, 35 MZ Large Grassy Platforms and Burning Grass.asm"
-Map_Fire:	include	"_maps/Fireballs.asm"
+Map_Fire:	include	"_maps/Fireballs.asm" ; reused by many objects
 		include	"_incObj/30 MZ Large Green Glass Blocks.asm"
 		include	"_incObj/31 MZ Chained Stompers.asm"
 		include	"_incObj/45 Unused - MZ Sideways Stomper.asm"
-Map_CStom:	include	"_maps/Chained Stompers.asm"
-Map_SStom:	include	"_maps/Sideways Stomper.asm"
+		includes_chainedstomper
+		includes_sidewaysstomper
 		include	"_incObj/32 Button.asm"
 		include	"_incObj/33 MZ, LZ Pushable Blocks.asm"
-
 
 ; ===========================================================================
 ; >>> Title card objects
@@ -4130,17 +4117,15 @@ Map_SStom:	include	"_maps/Sideways Stomper.asm"
 		include	"_incObj/3A Got Through Card.asm"
 		include	"_incObj/7E, 7F Special Stage Results and Chaos Emeralds.asm"
 		include	"_maps/Title Cards.asm"	; includes "Map_Card", "Map_Over", "Map_Got", and "Map_SSR"
-Map_SSRC:	include	"_maps/SS Result Chaos Emeralds.asm"
-
+		includes_ssrchaos
 
 ; ===========================================================================
 ; >>> More level objects
 		include	"_incObj/36 Spikes.asm"
 		include	"_incObj/3B GHZ Purple Rock.asm"
 		include	"_incObj/49 GHZ Waterfall Sound.asm"
-Map_PRock:	include	"_maps/Purple Rock.asm"
-		include	"_incObj/3C GHZ, SLZ Smashable Wall.asm"	; includes SmashObject
-
+		includes_purplerock
+		include	"_incObj/3C GHZ, SLZ Smashable Wall.asm" ; includes SmashObject
 
 ; ===========================================================================
 ; Subroutines to run, render, and update objects
@@ -4154,9 +4139,8 @@ Map_PRock:	include	"_maps/Purple Rock.asm"
 		include	"_inc/ObjPosLoad.asm"
 		include	"_incObj/sub FindFreeObj.asm"
 
-
 ; ===========================================================================
-; >>> More level obejcts
+; >>> More level objects
 		include	"_incObj/41 Springs.asm"
 		include	"_incObj/42 Badnik - Newtron.asm"
 		include	"_incObj/43 Badnik - Roller.asm"
@@ -4170,10 +4154,10 @@ Map_PRock:	include	"_maps/Purple Rock.asm"
 		include	"_incObj/4C, 4D MZ Lava Geyser and Maker.asm"
 		include	"_incObj/4E MZ Wall of Lava.asm"
 		include	"_incObj/54 MZ Invisible Lava Tag.asm"
-		include	"_anim/Lava Geyser.asm"
-		include	"_anim/Wall of Lava.asm"
-Map_Geyser:	include	"_maps/Lava Geyser.asm"
-Map_LWall:	include	"_maps/Wall of Lava.asm"
+		includes_lavageyser_anim
+		includes_walloflava_anim
+		includes_lavageyser_maps
+		includes_walloflava_maps
 		include	"_incObj/40 Badnik - Moto Bug.asm" ; includes "_incObj/sub RememberState.asm" subroutine
 		include	"_incObj/4F Unused - Blank.asm" ; this was Splats in the prototype
 		include	"_incObj/50 Badnik - Yadrin.asm"
@@ -4203,25 +4187,19 @@ Map_LWall:	include	"_maps/Wall of Lava.asm"
 		include	"_incObj/64 LZ Air Bubbles.asm"
 		include	"_incObj/65 LZ Waterfalls.asm"
 
-
 ; ===========================================================================
 ; >>> Main Sonic player object
 		include	"_incObj/01 Sonic.asm"
 
-
 ; ===========================================================================
 ; >>> Various unique objects
-		include	"_incObj/0A LZ Drowning Countdown.asm"	; includes ResumeMusic
+		include	"_incObj/0A LZ Drowning Countdown.asm" ; includes ResumeMusic
 		include	"_incObj/38 Shield and Invincibility.asm"
 		include	"_incObj/4A Unused - Special Stage Entry.asm"
 		include	"_incObj/08 LZ Water Splash.asm"
-		include	"_anim/Shield and Invincibility.asm"
-Map_Shield:	include	"_maps/Shield and Invincibility.asm"
-		include	"_anim/Special Stage Entry (Unused).asm"
-Map_Vanish:	include	"_maps/Special Stage Entry (Unused).asm"
-		include	"_anim/Water Splash.asm"
-Map_Splash:	include	"_maps/Water Splash.asm"
-
+		includes_shieldandstars
+		includes_ssentryunused
+		includes_watersplash
 
 ; ===========================================================================
 ; >>> Collision subroutines for Sonic and other objects
@@ -4229,7 +4207,6 @@ Map_Splash:	include	"_maps/Water Splash.asm"
 		include	"_incObj/sub FindNearestTile & FindFloor & FindWall.asm"
 		include "_inc/ConvertCollisionArray (Unused).asm"
 		include	"_incObj/Sonic Collision.asm"
-
 
 ; ===========================================================================
 ; >>> SBZ level objects
@@ -4252,11 +4229,10 @@ Map_Splash:	include	"_maps/Water Splash.asm"
 		include	"_incObj/7D Hidden Bonuses.asm"
 		include	"_incObj/8A Credits and Sonic Team Presents.asm"
 
-
 ; ===========================================================================
 ; >>> Bosses and related objects
-		include	"_incObj/3D, 48 Boss - GHZ Main and Wrecking Ball.asm"	; includes "BossDeafeated" and "BossMove" subroutines
-		include	"_anim/Eggman.asm"
+		include	"_incObj/3D, 48 Boss - GHZ Main and Wrecking Ball.asm" ; includes "BossDeafeated" and "BossMove" subroutines
+		include	"_anim/Eggman.asm" ; Eggman assets are reused by all bosses
 Map_Eggman:	include	"_maps/Eggman.asm"
 Map_BossItems:	include	"_maps/Boss Items.asm"
 		include	"_incObj/77 Boss - LZ Main.asm"
@@ -4267,34 +4243,23 @@ Map_BossItems:	include	"_maps/Boss Items.asm"
 		include	"_incObj/85,84,86 Boss - FZ Main, Cylinders, and Plasma Balls.asm"
 		include	"_incObj/3E Prison Capsule.asm"
 
-
 ; ===========================================================================
 ; >>> Object-to-object touch response handler for Sonic
 		include	"_incObj/Sonic ReactToItem.asm"
 
-
 ; ===========================================================================
 ; >>> Special Stage rendering and objects
-		include	"_inc/Special Stage Loading & Drawing.asm" ; includes the subroutines "SS_ShowLayout", "SS_AniWallsRings", 
-								   ; "SS_FindFreeAnimationSlot", "SS_AniItems", and "SS_Load"
+		include	"_inc/Special Stage Loading & Drawing.asm" ; includes "SS_ShowLayout" and "SS_Load"
 		include	"_inc/Special Stage Mappings & VRAM Pointers.asm"
-Map_SS_Shared:	include	"_maps/SS Shared Block.asm"
-Map_SS_Glass:	include	"_maps/SS Glass Block.asm"
-Map_SS_Up:	include	"_maps/SS UP Block.asm"
-Map_SS_Down:	include	"_maps/SS DOWN Block.asm"
-Map_SS_Chaos:	include	"_maps/SS Chaos Emeralds.asm"
 		include	"_incObj/09 Sonic in Special Stage.asm"
-
 
 ; ===========================================================================
 ; >>> Deleted, blank object that is randomly mixed in here
 		include	"_incObj/10 Unused - Blank.asm" ; this was an animation test object for Sonic in the prototype
 
-
 ; ===========================================================================
 ; >>> Subroutine for in-place level animations in VRAM
 		include	"_inc/AnimateLevelGfx.asm"
-
 
 ; ===========================================================================
 ; >>> HUD objects
@@ -4307,11 +4272,9 @@ Art_Hud:	binclude "artunc/HUD Numbers.unc" ; 8x16 pixel numbers on HUD
 Art_LivesNums:	binclude "artunc/Lives Counter Numbers.unc" ; 8x8 pixel numbers on lives counter
 		even
 
-
 ; ===========================================================================
 ; >>> Debug Mode
 		include	"_incObj/DebugMode.asm"
-
 
 ; ===========================================================================
 ; >>> Level definitions
@@ -4320,7 +4283,6 @@ Art_LivesNums:	binclude "artunc/Lives Counter Numbers.unc" ; 8x8 pixel numbers o
 
 
 ; ===========================================================================
-
 ; ---------------------------------------------------------------------------
 ; >> END OF PRIMARY INCLUDES - Everything below this point is art includes <<
 ; ---------------------------------------------------------------------------
@@ -4407,7 +4369,7 @@ Nem_Goggle:	binclude	"artnem/Unused - Goggles.nem" ; unused goggles
 ; ---------------------------------------------------------------------------
 ; Compressed graphics - special stage
 ; ---------------------------------------------------------------------------
-Map_SSWalls:	include	"_maps/SS Walls.asm"
+Map_SSWalls:	includes_sswalls_maps
 
 Nem_SSWalls:	binclude	"artnem/Special Walls.nem" ; special stage walls
 		even


### PR DESCRIPTION
This isn't meant to be a PR with the immediate intention of getting it merged, but rather something to debate first.

So, for context, recently I've finally moved most of the mappings/animations includes to be inside the incObj files themselves, in an attempt to properly group them together. I say most because in some cases this isn't possible, because for some reason a handful of mappings and animations are included at completely disjointed ROM locations (a good example being the Ball Hog badnik).

[I took some inspiration from Hivebrain 2022, and saw that he also ran into this issue, trying to solve it through deferring macros.](https://github.com/cvghivebrain/s1disasm/blob/ba72041f3a7c695f2cc56c10f7bf114ac544a779/_Main.asm#L456) So I've added a similar approach here. But now, after looking at the result, I'm not really convinced anymore... Does this actually solve anything or does it only add even more confusion? What do you think?