### PR TITLE
added a note regarding "NemDecToRAM"

### DIFF
--- a/_inc/Decompression/Nemesis Decompression.asm
+++ b/_inc/Decompression/Nemesis Decompression.asm
@@ -17,7 +17,9 @@ NemDec:
 
 ; ---------------------------------------------------------------------------
 ; Nemesis decompression subroutine, decompresses art to RAM
-; 
+;
+; Note, this part actually goes unused in Sonic 1, later games do use this
+;
 ; input:
 ; 	a0 = art address
 ; 	a4 = destination RAM address


### PR DESCRIPTION
NemDecToRAM is actually unused in Sonic 1, so thought I'd point that out